### PR TITLE
`Structured tests`: Add strictOrder for parameters

### DIFF
--- a/src/main/java/de/tum/in/test/api/structural/ConstructorTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ConstructorTestProvider.java
@@ -103,8 +103,7 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 			var expectedParameters = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_PARAMETERS);
 			var expectedModifiers = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_ANNOTATIONS);
-			var strictParameterOrder = getExpectedJsonBooleanProperty(expectedConstructor,
-					JSON_PROPERTY_STRICT_ORDER);
+			var strictParameterOrder = getExpectedJsonBooleanProperty(expectedConstructor, JSON_PROPERTY_STRICT_ORDER);
 
 			var parametersAreRight = false;
 			var modifiersAreRight = false;

--- a/src/main/java/de/tum/in/test/api/structural/ConstructorTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ConstructorTestProvider.java
@@ -103,6 +103,8 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 			var expectedParameters = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_PARAMETERS);
 			var expectedModifiers = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_ANNOTATIONS);
+			boolean strictParameterOrder = getExpectedJsonBooleanProperty(expectedConstructor,
+					JSON_PROPERTY_Strict_Order);
 
 			var parametersAreRight = false;
 			var modifiersAreRight = false;
@@ -113,7 +115,7 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 				var observedModifiers = Modifier.toString(observedConstructor.getModifiers()).split(" ");
 				var observedAnnotations = observedConstructor.getAnnotations();
 
-				parametersAreRight = checkParameters(observedParameters, expectedParameters);
+				parametersAreRight = checkParameters(observedParameters, expectedParameters, strictParameterOrder);
 				modifiersAreRight = checkModifiers(observedModifiers, expectedModifiers);
 				annotationsAreRight = checkAnnotations(observedAnnotations, expectedAnnotations);
 

--- a/src/main/java/de/tum/in/test/api/structural/ConstructorTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ConstructorTestProvider.java
@@ -103,8 +103,8 @@ public abstract class ConstructorTestProvider extends StructuralTestProvider {
 			var expectedParameters = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_PARAMETERS);
 			var expectedModifiers = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedConstructor, JSON_PROPERTY_ANNOTATIONS);
-			boolean strictParameterOrder = getExpectedJsonBooleanProperty(expectedConstructor,
-					JSON_PROPERTY_Strict_Order);
+			var strictParameterOrder = getExpectedJsonBooleanProperty(expectedConstructor,
+					JSON_PROPERTY_STRICT_ORDER);
 
 			var parametersAreRight = false;
 			var modifiersAreRight = false;

--- a/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
@@ -104,7 +104,7 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 			var expectedModifiers = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_ANNOTATIONS);
 			var expectedReturnType = expectedMethod.getString(JSON_PROPERTY_RETURN_TYPE);
-			boolean strictParameterOrder = getExpectedJsonBooleanProperty(expectedMethod, JSON_PROPERTY_Strict_Order);
+			var strictParameterOrder = getExpectedJsonBooleanProperty(expectedMethod, JSON_PROPERTY_STRICT_ORDER);
 			var checks = new MethodChecks();
 			for (Method observedMethod : observedClass.getDeclaredMethods()) {
 				// TODO: check if overloading is supported properly

--- a/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
@@ -104,12 +104,14 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 			var expectedModifiers = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_MODIFIERS);
 			var expectedAnnotations = getExpectedJsonProperty(expectedMethod, JSON_PROPERTY_ANNOTATIONS);
 			var expectedReturnType = expectedMethod.getString(JSON_PROPERTY_RETURN_TYPE);
+			boolean strictParameterOrder = getExpectedJsonBooleanProperty(expectedMethod, JSON_PROPERTY_Strict_Order);
 			var checks = new MethodChecks();
 			for (Method observedMethod : observedClass.getDeclaredMethods()) {
 				// TODO: check if overloading is supported properly
 				if (expectedName.equals(observedMethod.getName())) {
 					checks.name = true;
-					checks.parameters = checkParameters(observedMethod.getParameterTypes(), expectedParameters);
+					checks.parameters = checkParameters(observedMethod.getParameterTypes(), expectedParameters,
+							strictParameterOrder);
 					checks.modifiers = checkModifiers(Modifier.toString(observedMethod.getModifiers()).split(" "),
 							expectedModifiers);
 					checks.annotations = checkAnnotations(observedMethod.getAnnotations(), expectedAnnotations);

--- a/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
@@ -78,6 +78,7 @@ public abstract class StructuralTestProvider {
 	protected static final String JSON_PROPERTY_TYPE = "type";
 	protected static final String JSON_PROPERTY_RETURN_TYPE = "returnType";
 	protected static final String JSON_PROPERTY_ENUM_VALUES = "enumValues";
+	protected static final String JSON_PROPERTY_Strict_Order = "strictOrder";
 
 	protected static final String THE_CLASS = "The class ";
 	protected static final String THE_TYPE = "The type ";
@@ -135,6 +136,18 @@ public abstract class StructuralTestProvider {
 	 */
 	protected static JSONArray getExpectedJsonProperty(JSONObject element, String jsonPropertyKey) {
 		return element.has(jsonPropertyKey) ? element.getJSONArray(jsonPropertyKey) : new JSONArray();
+	}
+
+	/**
+	 * get the expected boolean value of the element or false
+	 *
+	 * @param element         the class, attribute, method or constructor JSON
+	 *                        object element
+	 * @param jsonPropertyKey the key used in JSON
+	 * @return a boolean as specified in the JSON or false if not present
+	 */
+	protected static boolean getExpectedJsonBooleanProperty(JSONObject element, String jsonPropertyKey) {
+		return element.has(jsonPropertyKey) ? element.getBoolean(jsonPropertyKey) : false;
 	}
 
 	/**
@@ -241,7 +254,8 @@ public abstract class StructuralTestProvider {
 	 * @param expectedParameters The expected parameter type names as a JSONArray.
 	 * @return True if they match, false otherwise.
 	 */
-	protected static boolean checkParameters(Class<?>[] observedParameters, JSONArray expectedParameters) {
+	protected static boolean checkParameters(Class<?>[] observedParameters, JSONArray expectedParameters,
+			boolean strictOrder) {
 		/*
 		 * If both the observed and expected elements have no parameters, then they
 		 * match.
@@ -254,20 +268,25 @@ public abstract class StructuralTestProvider {
 		 */
 		if (observedParameters.length != expectedParameters.length())
 			return false;
-		/*
-		 * Create hash tables to store how often a parameter type occurs. Checking the
-		 * occurrences of a certain parameter type is enough, since the parameter order
-		 * is not relevant to us.
-		 */
 		var expectedParameterTypeNames = new String[expectedParameters.length()];
 		for (var i = 0; i < expectedParameters.length(); i++)
 			expectedParameterTypeNames[i] = expectedParameters.getString(i);
-		Map<String, Integer> expectedParametersHashtable = createParametersHashMap(expectedParameterTypeNames);
 
 		var observedParameterTypeNames = new String[observedParameters.length];
 		for (var i = 0; i < observedParameters.length; i++)
 			// TODO: Canonical names should be supported as well.
 			observedParameterTypeNames[i] = observedParameters[i].getSimpleName();
+
+		if (strictOrder) {
+			return Arrays.equals(expectedParameterTypeNames, observedParameterTypeNames);
+		}
+
+		/*
+		 * Create hash tables to store how often a parameter type occurs. Checking the
+		 * occurrences of a certain parameter type is enough, since the parameter order
+		 * is not relevant to us.
+		 */
+		Map<String, Integer> expectedParametersHashtable = createParametersHashMap(expectedParameterTypeNames);
 		Map<String, Integer> observedParametersHashtable = createParametersHashMap(observedParameterTypeNames);
 
 		return expectedParametersHashtable.equals(observedParametersHashtable);

--- a/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
@@ -78,7 +78,7 @@ public abstract class StructuralTestProvider {
 	protected static final String JSON_PROPERTY_TYPE = "type";
 	protected static final String JSON_PROPERTY_RETURN_TYPE = "returnType";
 	protected static final String JSON_PROPERTY_ENUM_VALUES = "enumValues";
-	protected static final String JSON_PROPERTY_Strict_Order = "strictOrder";
+	protected static final String JSON_PROPERTY_STRICT_ORDER = "strictOrder";
 
 	protected static final String THE_CLASS = "The class ";
 	protected static final String THE_TYPE = "The type ";

--- a/src/test/java/de/tum/in/test/api/DynamicsTest.java
+++ b/src/test/java/de/tum/in/test/api/DynamicsTest.java
@@ -181,6 +181,6 @@ class DynamicsTest {
 	@TestTest
 	void test_method_throwing() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(method_throwing, RuntimeException.class,
-				"\n/// Mögliche Problemstelle: de.tum.in.testuser.subject.structural.SomeClass.throwException(SomeClass.java:56) ///"));
+				"\n/// Mögliche Problemstelle: de.tum.in.testuser.subject.structural.SomeClass.throwException(SomeClass.java:60) ///"));
 	}
 }

--- a/src/test/java/de/tum/in/test/api/StructuralTest.java
+++ b/src/test/java/de/tum/in/test/api/StructuralTest.java
@@ -40,7 +40,6 @@ class StructuralTest {
 	private final String testMethodsSomeAbstractClass = "testMethods()/dynamic-test:#4";
 	private final String testMethodsSomeFailingClass = "testMethods()/dynamic-test:#5";
 
-
 	@TestTest
 	void test_testAttributesSomeInterface() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testAttributesSomeInterface, AssertionFailedError.class,
@@ -144,9 +143,9 @@ class StructuralTest {
 
 	@TestTest
 	void test_testConstructorsSomeFailingClass() {
-		tests.assertThatEvents().haveExactly(1,
-				testFailedWith(testConstructorsSomeFailingClass, AssertionFailedError.class,
-						"The parameters of the expected constructor of the class 'SomeFailingClass' with the parameters: [\"int\",\"String\"] are not implemented as expected."));
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testConstructorsSomeFailingClass,
+				AssertionFailedError.class,
+				"The parameters of the expected constructor of the class 'SomeFailingClass' with the parameters: [\"int\",\"String\"] are not implemented as expected."));
 	}
 
 	@TestTest
@@ -178,5 +177,4 @@ class StructuralTest {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testMethodsSomeFailingClass, AssertionFailedError.class,
 				"The parameters of the expected method 'someMethodWithWrongParameterOrder' of the class 'SomeFailingClass' with the parameters: [\"int\",\"double\"] are not implemented as expected."));
 	}
-
 }

--- a/src/test/java/de/tum/in/test/api/StructuralTest.java
+++ b/src/test/java/de/tum/in/test/api/StructuralTest.java
@@ -33,10 +33,13 @@ class StructuralTest {
 	private final String testConstructorsSomeClass = "testConstructors()/dynamic-test:#1";
 	private final String testConstructorsSomeEnum = "testConstructors()/dynamic-test:#2";
 	private final String testConstructorsSomeAbstractClass = "testConstructors()/dynamic-test:#3";
+	private final String testConstructorsSomeFailingClass = "testConstructors()/dynamic-test:#4";
 	private final String testMethodsSomeInterface = "testMethods()/dynamic-test:#1";
 	private final String testMethodsSomeClass = "testMethods()/dynamic-test:#2";
 	private final String testMethodsSomeEnum = "testMethods()/dynamic-test:#3";
 	private final String testMethodsSomeAbstractClass = "testMethods()/dynamic-test:#4";
+	private final String testMethodsSomeFailingClass = "testMethods()/dynamic-test:#5";
+
 
 	@TestTest
 	void test_testAttributesSomeInterface() {
@@ -140,6 +143,13 @@ class StructuralTest {
 	}
 
 	@TestTest
+	void test_testConstructorsSomeFailingClass() {
+		tests.assertThatEvents().haveExactly(1,
+				testFailedWith(testConstructorsSomeFailingClass, AssertionFailedError.class,
+						"The parameters of the expected constructor of the class 'SomeFailingClass' with the parameters: [\"int\",\"String\"] are not implemented as expected."));
+	}
+
+	@TestTest
 	void test_testMethodsSomeInterface() {
 		tests.assertThatEvents().haveExactly(1,
 				event(testWithSegments(testMethodsSomeInterface), finishedSuccessfullyRep()));
@@ -162,4 +172,11 @@ class StructuralTest {
 		tests.assertThatEvents().haveExactly(1,
 				event(testWithSegments(testMethodsSomeAbstractClass), finishedSuccessfullyRep()));
 	}
+
+	@TestTest
+	void test_testMethodsSomeFailingClass() {
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testMethodsSomeFailingClass, AssertionFailedError.class,
+				"The parameters of the expected method 'someMethodWithWrongParameterOrder' of the class 'SomeFailingClass' with the parameters: [\"int\",\"double\"] are not implemented as expected."));
+	}
+
 }

--- a/src/test/java/de/tum/in/testuser/subject/structural/SomeClass.java
+++ b/src/test/java/de/tum/in/testuser/subject/structural/SomeClass.java
@@ -52,6 +52,10 @@ public class SomeClass implements SomeInterface {
 		return Math.max(someFinalAttribute, someInt);
 	}
 
+	public int doSomethingWithMoreParameters(int someInt, double someDouble, String someString) {
+		return (int) (someString.length() * someInt / someDouble);
+	}
+
 	public void throwException() {
 		throw new RuntimeException();
 	}

--- a/src/test/java/de/tum/in/testuser/subject/structural/SomeClass.java
+++ b/src/test/java/de/tum/in/testuser/subject/structural/SomeClass.java
@@ -52,7 +52,7 @@ public class SomeClass implements SomeInterface {
 		return Math.max(someFinalAttribute, someInt);
 	}
 
-	public int doSomethingWithMoreParameters(int someInt, double someDouble, String someString) {
+	private int doSomethingWithMoreParameters(int someInt, double someDouble, String someString) {
 		return (int) (someString.length() * someInt / someDouble);
 	}
 

--- a/src/test/java/de/tum/in/testuser/subject/structural/SomeFailingClass.java
+++ b/src/test/java/de/tum/in/testuser/subject/structural/SomeFailingClass.java
@@ -4,6 +4,14 @@ public class SomeFailingClass {
 
 	public static final int SOME_CONSTANT = calculateConstant();
 
+	public SomeFailingClass(String someString, int someInt) {
+
+	}
+
+	public void someMethodWithWrongParameterOrder(double someDouble, int someInt) {
+		// Do nothing
+	}
+	
 	public static int calculateConstant() {
 		throw new RuntimeException();
 	}

--- a/src/test/java/de/tum/in/testuser/subject/structural/SomeFailingClass.java
+++ b/src/test/java/de/tum/in/testuser/subject/structural/SomeFailingClass.java
@@ -5,13 +5,13 @@ public class SomeFailingClass {
 	public static final int SOME_CONSTANT = calculateConstant();
 
 	public SomeFailingClass(String someString, int someInt) {
-
+		// Do nothing
 	}
 
 	public void someMethodWithWrongParameterOrder(double someDouble, int someInt) {
 		// Do nothing
 	}
-	
+
 	public static int calculateConstant() {
 		throw new RuntimeException();
 	}

--- a/src/test/resources/de/tum/in/testuser/test.json
+++ b/src/test/resources/de/tum/in/testuser/test.json
@@ -64,12 +64,12 @@
     "parameters" : [ "int" ],
     "returnType" : "int"
   }, {
-      "name" : "doSomethingWithMoreParameters",
-      "modifiers" : [ "public" ],
-      "parameters" : [ "int", "double", "String" ],
-      "strictOrder" : true,
-      "returnType" : "int"
-  }],
+    "name" : "doSomethingWithMoreParameters",
+    "modifiers" : [ "public" ],
+    "parameters" : [ "int", "double", "String" ],
+    "strictOrder" : true,
+    "returnType" : "int"
+  } ],
   "constructors" : [ {
     "parameters" : [ "String" ]
   } ],
@@ -143,15 +143,17 @@
     "name" : "SOME_CONSTANT",
     "modifiers" : [ "penguin: final" ],
     "type" : "int"
-  } ], "methods" : [ {
+  } ],
+  "methods" : [ {
     "name" : "someMethodWithWrongParameterOrder",
     "modifiers" : [ "public" ],
     "parameters" : [ "int", "double" ],
     "strictOrder" : true,
     "returnType" : "void"
-  } ], "constructors" : [ {
+  } ],
+  "constructors" : [ {
     "modifiers" : [ "protected" ],
     "parameters" : [ "int", "String" ],
     "strictOrder" : true
-  } ],
+  } ]
 } ]

--- a/src/test/resources/de/tum/in/testuser/test.json
+++ b/src/test/resources/de/tum/in/testuser/test.json
@@ -65,7 +65,7 @@
     "returnType" : "int"
   }, {
     "name" : "doSomethingWithMoreParameters",
-    "modifiers" : [ "public" ],
+    "modifiers" : [ "private" ],
     "parameters" : [ "int", "double", "String" ],
     "strictOrder" : true,
     "returnType" : "int"

--- a/src/test/resources/de/tum/in/testuser/test.json
+++ b/src/test/resources/de/tum/in/testuser/test.json
@@ -63,7 +63,13 @@
     "modifiers" : [ "public" ],
     "parameters" : [ "int" ],
     "returnType" : "int"
-  } ],
+  }, {
+      "name" : "doSomethingWithMoreParameters",
+      "modifiers" : [ "public" ],
+      "parameters" : [ "int", "double", "String" ],
+      "strictOrder" : true,
+      "returnType" : "int"
+  }],
   "constructors" : [ {
     "parameters" : [ "String" ]
   } ],
@@ -137,5 +143,15 @@
     "name" : "SOME_CONSTANT",
     "modifiers" : [ "penguin: final" ],
     "type" : "int"
-  } ]
+  } ], "methods" : [ {
+    "name" : "someMethodWithWrongParameterOrder",
+    "modifiers" : [ "public" ],
+    "parameters" : [ "int", "double" ],
+    "strictOrder" : true,
+    "returnType" : "void"
+  } ], "constructors" : [ {
+    "modifiers" : [ "protected" ],
+    "parameters" : [ "int", "String" ],
+    "strictOrder" : true
+  } ],
 } ]


### PR DESCRIPTION
The structural tests are often used to check whether the student implemented the expected structure and especially methods.
This simplifies the behavior tests, since reflections can be avoided.

Currently the order of parameters is irrelevant for checking methods. This grants the students more freedom, but can make the behavior tests more complicated.

This PR adds the "strictOrder" tag to methods and constructors, which forces the student to exactly follow the expected order of parameters.