### PR TITLE
Change compile scope of Ares dependency in Gradle project

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ in the `dependencies` section.
 For Gradle projects, include
 [source,groovy]
 ----
-implementation 'de.tum.in.ase:artemis-java-test-sandbox:1.9.0'
+testImplementation 'de.tum.in.ase:artemis-java-test-sandbox:1.9.0'
 ----
 
 in the `dependencies` section.

--- a/src/test/resources/de/tum/in/test/integration/testuser/build.gradle
+++ b/src/test/resources/de/tum/in/test/integration/testuser/build.gradle
@@ -6,7 +6,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-    implementation 'de.tum.in.ase:artemis-java-test-sandbox:+'
+    testImplementation 'de.tum.in.ase:artemis-java-test-sandbox:+'
 }
 def assignmentSrcDir = "src/test/java"
 def studentOutputDir = sourceSets.main.java.destinationDirectory.get()


### PR DESCRIPTION
The Ares dependency is only needed for compiling the test classes, therefore the compile scope can be changed in the build.gradle.