### PR TITLE
Allow access to (package) private and protected attributes, constructors, and methods

### DIFF
--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -63,7 +63,7 @@ class ClassMemberAccessor {
 			throws NoSuchMethodException {
 		return getClassHierarchy(declaringClass).flatMap(c -> {
 			try {
-				return getInheritedMethod(declaringClass, c, methodName, parameterTypes);
+				return getInheritedMethod(declaringClass, c, methodName, parameterTypes).stream();
 			} catch (NoSuchMethodException nsme) {
 				return Stream.empty();
 			}
@@ -82,13 +82,13 @@ class ClassMemberAccessor {
 	 * @throws NoSuchMethodException Thrown if no method as specified could be found
 	 *                               in either class.
 	 */
-	private static Stream<Method> getInheritedMethod(Class<?> targetClass, Class<?> declaringClass, String methodName,
+	private static Optional<Method> getInheritedMethod(Class<?> targetClass, Class<?> declaringClass, String methodName,
 			Class<?>[] parameterTypes) throws NoSuchMethodException {
 		Method method = declaringClass.getDeclaredMethod(methodName, parameterTypes);
 		if (isInheritable(targetClass, declaringClass, method.getModifiers(), true)) {
-			return Stream.of(method);
+			return Optional.of(method);
 		} else {
-			return Stream.empty();
+			return Optional.empty();
 		}
 	}
 

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -42,7 +42,7 @@ class ClassMemberAccessor {
 				} else {
 					return Stream.of(c.getMethod(methodName, parameterTypes));
 				}
-			} catch (NoSuchMethodException nmse) {
+			} catch (NoSuchMethodException nsme) {
 				return Stream.empty();
 			}
 		}).findFirst().orElseThrow(() -> new NoSuchMethodException(methodName));
@@ -63,7 +63,7 @@ class ClassMemberAccessor {
 	private static Stream<Method> getInheritedMethod(Class<?> targetClass, Class<?> declaringClass, String methodName,
 			Class<?>[] parameterTypes) throws NoSuchMethodException {
 		Method method = declaringClass.getDeclaredMethod(methodName, parameterTypes);
-		if (isInherited(targetClass, declaringClass, method.getModifiers())) {
+		if (isInheritable(targetClass, declaringClass, method.getModifiers())) {
 			return Stream.of(method);
 		} else {
 			return Stream.empty();
@@ -115,7 +115,7 @@ class ClassMemberAccessor {
 	private static Optional<Field> getInheritedField(Class<?> targetClass, Class<?> declaringClass, String fieldName)
 			throws NoSuchFieldException {
 		Field field = declaringClass.getDeclaredField(fieldName);
-		if (isInherited(targetClass, declaringClass, field.getModifiers())) {
+		if (isInheritable(targetClass, declaringClass, field.getModifiers())) {
 			return Optional.of(field);
 		} else {
 			return Optional.empty();
@@ -151,7 +151,10 @@ class ClassMemberAccessor {
 	 * @return True, if the class member of {@code declaredInClass} is accessible in
 	 *         its subclass {@code targetClass}.
 	 */
-	private static boolean isInherited(Class<?> targetClass, Class<?> declaredInClass, int modifier) {
-		return targetClass.equals(declaredInClass) || !Modifier.isPrivate(modifier);
+	private static boolean isInheritable(Class<?> targetClass, Class<?> declaredInClass, int modifier) {
+		boolean isInheritable = Modifier.isProtected(modifier) || Modifier.isPublic(modifier);
+		boolean isInheritableInPackage = !Modifier.isPrivate(modifier)
+				&& targetClass.getPackage().equals(declaredInClass.getPackage());
+		return targetClass.equals(declaredInClass) || isInheritable || isInheritableInPackage;
 	}
 }

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -22,7 +22,7 @@ class ClassMemberAccessor {
 	 * Also recursively searches for an inherited method in all superclasses and
 	 * implemented interfaces.
 	 *
-	 * @param declaringClass The class that declares or inherits the method.
+	 * @param clazz          The class that declares or inherits the method.
 	 * @param methodName     The name of the method.
 	 * @param findPrivate    True, if this method should search for (package)
 	 *                       private or protected (inherited) methods.
@@ -30,19 +30,19 @@ class ClassMemberAccessor {
 	 * @return The wanted method.
 	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
 	 */
-	static Method getMethod(Class<?> declaringClass, String methodName, boolean findPrivate, Class<?>[] parameterTypes)
+	static Method getMethod(Class<?> clazz, String methodName, boolean findPrivate, Class<?>[] parameterTypes)
 			throws NoSuchMethodException {
 		if (!findPrivate) {
 			try {
-				return declaringClass.getMethod(methodName, parameterTypes);
+				return clazz.getMethod(methodName, parameterTypes);
 			} catch (NoSuchMethodException nsme) {
 				// Also search for declared methods in the own class even when not explicitly
 				// searching for private methods to be able to provide error messages to the
 				// users that the method exists, but with the wrong visibility.
-				return declaringClass.getDeclaredMethod(methodName, parameterTypes);
+				return clazz.getDeclaredMethod(methodName, parameterTypes);
 			}
 		} else {
-			return getPrivateMethod(declaringClass, methodName, parameterTypes);
+			return getPrivateMethod(clazz, methodName, parameterTypes);
 		}
 	}
 
@@ -99,25 +99,25 @@ class ClassMemberAccessor {
 	 * implemented interfaces. Finds a field even if it is not declared to be
 	 * visible outside the declaring class.
 	 *
-	 * @param declaringClass The class that declares or inherits the field.
-	 * @param fieldName      The name of the attribute.
-	 * @param findPrivate    True, if this method should search for (package)
-	 *                       private or protected (inherited) attributes.
+	 * @param clazz       The class that declares or inherits the field.
+	 * @param fieldName   The name of the attribute.
+	 * @param findPrivate True, if this method should search for (package) private
+	 *                    or protected (inherited) attributes.
 	 * @return The wanted field.
 	 * @throws NoSuchFieldException Thrown if the specified field cannot be found.
 	 */
-	static Field getField(Class<?> declaringClass, String fieldName, boolean findPrivate) throws NoSuchFieldException {
+	static Field getField(Class<?> clazz, String fieldName, boolean findPrivate) throws NoSuchFieldException {
 		if (!findPrivate) {
 			try {
-				return declaringClass.getField(fieldName);
+				return clazz.getField(fieldName);
 			} catch (NoSuchFieldException nsfe) {
 				// Also search for declared fields in the own class even when not explicitly
 				// searching for private fields to be able to provide error messages to the
 				// users that the field exists, but with the wrong visibility.
-				return declaringClass.getDeclaredField(fieldName);
+				return clazz.getDeclaredField(fieldName);
 			}
 		} else {
-			return getPrivateField(declaringClass, fieldName);
+			return getPrivateField(clazz, fieldName);
 		}
 	}
 

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -1,5 +1,7 @@
 package de.tum.in.test.api.util;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 /**
@@ -22,7 +24,7 @@ class ClassMemberAccessor {
 	 * @return The wanted method.
 	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
 	 */
-	static Method getMethod(Class<?> declaringClass, String methodName, boolean findPrivate, Class<?>... parameterTypes)
+	static Method getMethod(Class<?> declaringClass, String methodName, boolean findPrivate, Class<?>[] parameterTypes)
 			throws NoSuchMethodException {
 		if (!findPrivate) {
 			return declaringClass.getMethod(methodName, parameterTypes);
@@ -43,7 +45,7 @@ class ClassMemberAccessor {
 	 * @return The wanted method.
 	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
 	 */
-	private static Method getPrivateMethod(Class<?> declaringClass, String methodName, Class<?>... parameterTypes)
+	private static Method getPrivateMethod(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes)
 			throws NoSuchMethodException {
 		try {
 			return declaringClass.getDeclaredMethod(methodName, parameterTypes);
@@ -53,6 +55,51 @@ class ClassMemberAccessor {
 				throw nmse;
 			} else {
 				return getPrivateMethod(superClass, methodName, parameterTypes);
+			}
+		}
+	}
+
+	static Field getAttribute(Class<?> declaringClass, String fieldName, boolean findPrivate)
+			throws NoSuchFieldException {
+		if (!findPrivate) {
+			return declaringClass.getDeclaredField(fieldName);
+		} else {
+			return getPrivateField(declaringClass, fieldName);
+		}
+	}
+
+	private static Field getPrivateField(Class<?> declaringClass, String fieldName) throws NoSuchFieldException {
+		try {
+			return declaringClass.getDeclaredField(fieldName);
+		} catch (NoSuchFieldException nsfe) {
+			Class<?> superClass = declaringClass.getSuperclass();
+			if (superClass == null) {
+				throw nsfe;
+			} else {
+				return getPrivateField(superClass, fieldName);
+			}
+		}
+	}
+
+	static Constructor<?> getConstructor(Class<?> declaringClass, boolean findPrivate, Class<?>... parameterTypes)
+			throws NoSuchMethodException {
+		if (!findPrivate) {
+			return declaringClass.getDeclaredConstructor(parameterTypes);
+		} else {
+			return getPrivateConstructor(declaringClass, parameterTypes);
+		}
+	}
+
+	private static Constructor<?> getPrivateConstructor(Class<?> declaringClass, Class<?>[] parameterTypes)
+			throws NoSuchMethodException {
+		try {
+			return declaringClass.getDeclaredConstructor(parameterTypes);
+		} catch (NoSuchMethodException nmse) {
+			Class<?> superClass = declaringClass.getSuperclass();
+			if (superClass == null) {
+				throw nmse;
+			} else {
+				return getPrivateConstructor(superClass, parameterTypes);
 			}
 		}
 	}

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -1,8 +1,12 @@
 package de.tum.in.test.api.util;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Provides utility methods to access public, (package) private and protected
@@ -14,93 +18,132 @@ class ClassMemberAccessor {
 
 	/**
 	 * Retrieve a method with arguments of a given class by its name.
+	 * <p>
+	 * Also recursively searches for the method in all superclasses and implemented
+	 * interfaces.
 	 *
-	 * @param declaringClass The class that declares this method.
-	 * @param methodName     The name of this method.
+	 * @param declaringClass The class that declares or inherits the method.
+	 * @param methodName     The name of the method.
 	 * @param findPrivate    True, if this method should search for (package)
 	 *                       private or protected (inherited) methods.
-	 * @param parameterTypes The parameter types of this method. Do not include if
-	 *                       the method has no parameters.
+	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
 	 */
 	static Method getMethod(Class<?> declaringClass, String methodName, boolean findPrivate, Class<?>[] parameterTypes)
 			throws NoSuchMethodException {
-		if (!findPrivate) {
-			return declaringClass.getMethod(methodName, parameterTypes);
+		return getClassHierarchy(declaringClass).flatMap(c -> {
+			try {
+				if (c.equals(declaringClass) || findPrivate) {
+					return getInheritedMethod(declaringClass, c, methodName, parameterTypes);
+				} else {
+					return Stream.of(c.getMethod(methodName, parameterTypes));
+				}
+			} catch (NoSuchMethodException nmse) {
+				return Stream.empty();
+			}
+		}).findFirst().orElseThrow(() -> new NoSuchMethodException(methodName));
+	}
+
+	/**
+	 * Searches for a method in the target class that might be inherited from the
+	 * declaring class.
+	 *
+	 * @param targetClass    The class in which the method should be accessible.
+	 * @param declaringClass The class from which the method might be inherited.
+	 * @param methodName     The name of the method.
+	 * @param parameterTypes The parameter types of the method.
+	 * @return A method that is accessible in the target class.
+	 * @throws NoSuchMethodException Thrown if no method as specified could be found
+	 *                               in either class.
+	 */
+	private static Stream<Method> getInheritedMethod(Class<?> targetClass, Class<?> declaringClass, String methodName,
+			Class<?>[] parameterTypes) throws NoSuchMethodException {
+		Method method = declaringClass.getDeclaredMethod(methodName, parameterTypes);
+		if (isInherited(targetClass, declaringClass, method.getModifiers())) {
+			return Stream.of(method);
 		} else {
-			return getPrivateMethod(declaringClass, methodName, parameterTypes);
+			return Stream.empty();
 		}
 	}
 
 	/**
-	 * Retrieve a method with arguments of a given class by its name.
+	 * Retrieve a field of a given class by its name.
 	 * <p>
-	 * Also searches in private and inherited (protected) methods.
+	 * Also recursively searches for the field in all superclasses and implemented
+	 * interfaces.
 	 *
-	 * @param declaringClass The class that declares this method.
-	 * @param methodName     The name of this method.
-	 * @param parameterTypes The parameter types of this method. Do not include if
-	 *                       the method has no parameters.
-	 * @return The wanted method.
-	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
+	 * @param declaringClass The class that declares or inherits the field.
+	 * @param fieldName      The name of the attribute.
+	 * @param findPrivate    True, if this method should search for (package)
+	 *                       private or protected (inherited) attributes.
+	 * @return The wanted field.
+	 * @throws NoSuchFieldException Thrown if the specified field cannot be found.
 	 */
-	private static Method getPrivateMethod(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes)
-			throws NoSuchMethodException {
-		try {
-			return declaringClass.getDeclaredMethod(methodName, parameterTypes);
-		} catch (NoSuchMethodException nmse) {
-			Class<?> superClass = declaringClass.getSuperclass();
-			if (superClass == null) {
-				throw nmse;
-			} else {
-				return getPrivateMethod(superClass, methodName, parameterTypes);
-			}
-		}
-	}
-
 	static Field getAttribute(Class<?> declaringClass, String fieldName, boolean findPrivate)
 			throws NoSuchFieldException {
-		if (!findPrivate) {
-			return declaringClass.getDeclaredField(fieldName);
-		} else {
-			return getPrivateField(declaringClass, fieldName);
-		}
-	}
-
-	private static Field getPrivateField(Class<?> declaringClass, String fieldName) throws NoSuchFieldException {
-		try {
-			return declaringClass.getDeclaredField(fieldName);
-		} catch (NoSuchFieldException nsfe) {
-			Class<?> superClass = declaringClass.getSuperclass();
-			if (superClass == null) {
-				throw nsfe;
-			} else {
-				return getPrivateField(superClass, fieldName);
+		return getClassHierarchy(declaringClass).flatMap(c -> {
+			try {
+				if (c.equals(declaringClass) || findPrivate) {
+					return getInheritedField(declaringClass, c, fieldName).stream();
+				} else {
+					return Stream.of(c.getField(fieldName));
+				}
+			} catch (NoSuchFieldException nmse) {
+				return Stream.empty();
 			}
-		}
+		}).findFirst().orElseThrow(() -> new NoSuchFieldException(fieldName));
 	}
 
-	static Constructor<?> getConstructor(Class<?> declaringClass, boolean findPrivate, Class<?>... parameterTypes)
-			throws NoSuchMethodException {
-		if (!findPrivate) {
-			return declaringClass.getDeclaredConstructor(parameterTypes);
+	/**
+	 * Searches for a field in the target class that might be inherited from the
+	 * declaring class.
+	 *
+	 * @param targetClass    The class in which the field should be accessible.
+	 * @param declaringClass The class from which the field might be inherited.
+	 * @param fieldName      The name of the attribute.
+	 * @return A field that is accessible in the target class.
+	 * @throws NoSuchFieldException Thrown if no field with the given name could be
+	 *                              found in either class.
+	 */
+	private static Optional<Field> getInheritedField(Class<?> targetClass, Class<?> declaringClass, String fieldName)
+			throws NoSuchFieldException {
+		Field field = declaringClass.getDeclaredField(fieldName);
+		if (isInherited(targetClass, declaringClass, field.getModifiers())) {
+			return Optional.of(field);
 		} else {
-			return getPrivateConstructor(declaringClass, parameterTypes);
+			return Optional.empty();
 		}
 	}
 
-	private static Constructor<?> getPrivateConstructor(Class<?> declaringClass, Class<?>[] parameterTypes)
-			throws NoSuchMethodException {
-		try {
-			return declaringClass.getDeclaredConstructor(parameterTypes);
-		} catch (NoSuchMethodException nmse) {
-			Class<?> superClass = declaringClass.getSuperclass();
-			if (superClass == null) {
-				throw nmse;
-			} else {
-				return getPrivateConstructor(superClass, parameterTypes);
-			}
-		}
+	/**
+	 * Searches for all classes and interfaces the given class is inheriting from.
+	 * <p>
+	 * The given class itself is part of the result. Performs a depth-first search
+	 * starting with classes, then interfaces.
+	 *
+	 * @param clazz The class for which the inheritance tree should be traversed.
+	 * @return A stream of the given class and all superclasses and interfaces it
+	 *         inherits from.
+	 */
+	private static Stream<Class<?>> getClassHierarchy(Class<?> clazz) {
+		Stream<Class<?>> directSuperclasses = Stream
+				.concat(Stream.of(clazz.getSuperclass()), Arrays.stream(clazz.getInterfaces()))
+				.filter(Objects::nonNull);
+		return Stream.concat(Stream.of(clazz), directSuperclasses.flatMap(ClassMemberAccessor::getClassHierarchy));
+	}
+
+	/**
+	 * Checks if a field or method member of a class is accessible in a subclass.
+	 *
+	 * @param targetClass     The class in which the class member of
+	 *                        {@code declaredInClass} should be accessible.
+	 * @param declaredInClass The class in which the member was declared.
+	 * @param modifier        The modifiers of the member.
+	 * @return True, if the class member of {@code declaredInClass} is accessible in
+	 *         its subclass {@code targetClass}.
+	 */
+	private static boolean isInherited(Class<?> targetClass, Class<?> declaredInClass, int modifier) {
+		return targetClass.equals(declaredInClass) || !Modifier.isPrivate(modifier);
 	}
 }

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -113,9 +113,11 @@ class ClassMemberAccessor {
 		try {
 			return clazz.getField(fieldName);
 		} catch (@SuppressWarnings("unused") NoSuchFieldException nsfe) {
-			// Also search for declared fields in the own class even when not explicitly
-			// searching for private fields to be able to provide error messages to the
-			// users that the field exists, but with the wrong visibility.
+			/*
+			 * Also search for declared fields in the own class even when not explicitly
+			 * searching for private fields to be able to provide error messages to the
+			 * users that the field exists, but with the wrong visibility.
+			 */
 			return clazz.getDeclaredField(fieldName);
 		}
 	}

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -1,0 +1,59 @@
+package de.tum.in.test.api.util;
+
+import java.lang.reflect.Method;
+
+/**
+ * Provides utility methods to access public, (package) private and protected
+ * (inherited) members of classes.
+ */
+class ClassMemberAccessor {
+	private ClassMemberAccessor() {
+	}
+
+	/**
+	 * Retrieve a method with arguments of a given class by its name.
+	 *
+	 * @param declaringClass The class that declares this method.
+	 * @param methodName     The name of this method.
+	 * @param findPrivate    True, if this method should search for (package)
+	 *                       private or protected (inherited) methods.
+	 * @param parameterTypes The parameter types of this method. Do not include if
+	 *                       the method has no parameters.
+	 * @return The wanted method.
+	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
+	 */
+	static Method getMethod(Class<?> declaringClass, String methodName, boolean findPrivate, Class<?>... parameterTypes)
+			throws NoSuchMethodException {
+		if (!findPrivate) {
+			return declaringClass.getMethod(methodName, parameterTypes);
+		} else {
+			return getPrivateMethod(declaringClass, methodName, parameterTypes);
+		}
+	}
+
+	/**
+	 * Retrieve a method with arguments of a given class by its name.
+	 * <p>
+	 * Also searches in private and inherited (protected) methods.
+	 *
+	 * @param declaringClass The class that declares this method.
+	 * @param methodName     The name of this method.
+	 * @param parameterTypes The parameter types of this method. Do not include if
+	 *                       the method has no parameters.
+	 * @return The wanted method.
+	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
+	 */
+	private static Method getPrivateMethod(Class<?> declaringClass, String methodName, Class<?>... parameterTypes)
+			throws NoSuchMethodException {
+		try {
+			return declaringClass.getDeclaredMethod(methodName, parameterTypes);
+		} catch (NoSuchMethodException nmse) {
+			Class<?> superClass = declaringClass.getSuperclass();
+			if (superClass == null) {
+				throw nmse;
+			} else {
+				return getPrivateMethod(superClass, methodName, parameterTypes);
+			}
+		}
+	}
+}

--- a/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
+++ b/src/main/java/de/tum/in/test/api/util/ClassMemberAccessor.java
@@ -24,15 +24,15 @@ class ClassMemberAccessor {
 	 *
 	 * @param clazz          The class that declares or inherits the method.
 	 * @param methodName     The name of the method.
-	 * @param findPrivate    True, if this method should search for (package)
+	 * @param findNonPublic  True, if this method should search for (package)
 	 *                       private or protected (inherited) methods.
 	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
 	 */
-	static Method getMethod(Class<?> clazz, String methodName, boolean findPrivate, Class<?>[] parameterTypes)
+	static Method getMethod(Class<?> clazz, String methodName, boolean findNonPublic, Class<?>[] parameterTypes)
 			throws NoSuchMethodException {
-		if (!findPrivate) {
+		if (!findNonPublic) {
 			try {
 				return clazz.getMethod(methodName, parameterTypes);
 			} catch (NoSuchMethodException nsme) {
@@ -42,7 +42,7 @@ class ClassMemberAccessor {
 				return clazz.getDeclaredMethod(methodName, parameterTypes);
 			}
 		} else {
-			return getPrivateMethod(clazz, methodName, parameterTypes);
+			return getNonPublicMethod(clazz, methodName, parameterTypes);
 		}
 	}
 
@@ -59,7 +59,7 @@ class ClassMemberAccessor {
 	 * @return The wanted method.
 	 * @throws NoSuchMethodException Thrown if the specified method cannot be found.
 	 */
-	private static Method getPrivateMethod(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes)
+	private static Method getNonPublicMethod(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes)
 			throws NoSuchMethodException {
 		return getClassHierarchy(declaringClass).flatMap(c -> {
 			try {
@@ -99,15 +99,15 @@ class ClassMemberAccessor {
 	 * implemented interfaces. Finds a field even if it is not declared to be
 	 * visible outside the declaring class.
 	 *
-	 * @param clazz       The class that declares or inherits the field.
-	 * @param fieldName   The name of the attribute.
-	 * @param findPrivate True, if this method should search for (package) private
-	 *                    or protected (inherited) attributes.
+	 * @param clazz         The class that declares or inherits the field.
+	 * @param fieldName     The name of the attribute.
+	 * @param findNonPublic True, if this method should search for (package) private
+	 *                      or protected (inherited) attributes.
 	 * @return The wanted field.
 	 * @throws NoSuchFieldException Thrown if the specified field cannot be found.
 	 */
-	static Field getField(Class<?> clazz, String fieldName, boolean findPrivate) throws NoSuchFieldException {
-		if (!findPrivate) {
+	static Field getField(Class<?> clazz, String fieldName, boolean findNonPublic) throws NoSuchFieldException {
+		if (!findNonPublic) {
 			try {
 				return clazz.getField(fieldName);
 			} catch (NoSuchFieldException nsfe) {
@@ -117,7 +117,7 @@ class ClassMemberAccessor {
 				return clazz.getDeclaredField(fieldName);
 			}
 		} else {
-			return getPrivateField(clazz, fieldName);
+			return getNonPublicField(clazz, fieldName);
 		}
 	}
 
@@ -132,7 +132,7 @@ class ClassMemberAccessor {
 	 * @return The wanted field.
 	 * @throws NoSuchFieldException Thrown if the specified field cannot be found.
 	 */
-	private static Field getPrivateField(Class<?> declaringClass, String fieldName) throws NoSuchFieldException {
+	private static Field getNonPublicField(Class<?> declaringClass, String fieldName) throws NoSuchFieldException {
 		return getClassHierarchy(declaringClass).flatMap(c -> {
 			try {
 				return getInheritedField(declaringClass, c, fieldName).stream();

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -179,7 +179,7 @@ public final class ReflectionTestUtils {
 		var constructorArgTypes = getParameterTypes(constructorArgs, "reflection_test_utils.constructor_null_args", //$NON-NLS-1$
 				clazz.getSimpleName());
 		try {
-			Constructor<?> constructor = clazz.getDeclaredConstructor(constructorArgTypes);
+			Constructor<?> constructor = ClassMemberAccessor.getConstructor(clazz, forceAccess, constructorArgTypes);
 			return newInstanceAccessible(constructor, forceAccess, constructorArgs);
 		} catch (@SuppressWarnings("unused") NoSuchMethodException nsme) {
 			throw localizedFailure("reflection_test_utils.constructor_not_found_args", clazz.getSimpleName(), //$NON-NLS-1$
@@ -273,7 +273,7 @@ public final class ReflectionTestUtils {
 	private static Object valueForAttribute(Object object, String attributeName, boolean forceAccess) {
 		requireNonNull(object, "reflection_test_utils.attribute_null", attributeName); //$NON-NLS-1$
 		try {
-			Field field = object.getClass().getDeclaredField(attributeName);
+			Field field = ClassMemberAccessor.getAttribute(object.getClass(), attributeName, forceAccess);
 			if (forceAccess) {
 				field.setAccessible(true);
 			}

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -87,7 +87,7 @@ public final class ReflectionTestUtils {
 	 * <p>
 	 * This method does not support passing null, passing subclasses of the
 	 * parameter types or invoking constructors with primitive parameters. Use
-	 * {@link #newInstance(Constructor, Object...)} for that.
+	 * {@link #newInstanceFromPrivateConstructor(Constructor, Object...)} for that.
 	 * <p>
 	 * Forces the access to package-private, {@code protected}, and {@code private}
 	 * constructors. Use {@link #newInstance(String, Object...)} if you do not

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -74,8 +74,6 @@ public final class ReflectionTestUtils {
 	 *                           retrieved (package.classname)
 	 * @param constructorArgs    Parameter instances of the constructor of the
 	 *                           class, that it should use to get instantiated with.
-	 *                           Do not include, if the constructor has no
-	 *                           arguments.
 	 * @return The instance of this class.
 	 * @see #newInstance(Class, Object...)
 	 */
@@ -97,10 +95,8 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param qualifiedClassName The qualified name of the class that needs to get
 	 *                           retrieved (package.classname)
-	 * @param constructorArgs    Parameter instances of the constructor of the
-	 *                           class, that it should use to get instantiated with.
-	 *                           Do not include, if the constructor has no
-	 *                           arguments.
+	 * @param constructorArgs    Parameter instances of the constructor of the class
+	 *                           that it should use to get instantiated with.
 	 * @return The instance of this class.
 	 * @see #newInstance(Class, Object...)
 	 */
@@ -118,8 +114,7 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param clazz           The class for which a new instance should be created
 	 * @param constructorArgs Parameter instances of the constructor of the class,
-	 *                        that it should use to get instantiated with. Do not
-	 *                        include, if the constructor has no arguments.
+	 *                        that it should use to get instantiated with.
 	 * @return The instance of this class.
 	 */
 	public static Object newInstance(Class<?> clazz, Object... constructorArgs) {
@@ -132,7 +127,7 @@ public final class ReflectionTestUtils {
 	 * <p>
 	 * This method does not support passing null, passing subclasses of the
 	 * parameter types or invoking constructors with primitive parameters. Use
-	 * {@link #newInstance(Constructor, Object...)} for that.
+	 * {@link #newInstance(Constructor, Object[])} for that.
 	 * <p>
 	 * Forces the access to package-private, {@code protected}, and {@code private}
 	 * constructors. Use {@link #newInstance(Class, Object...)} if you do not
@@ -140,8 +135,7 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param clazz           The class for which a new instance should be created
 	 * @param constructorArgs Parameter instances of the constructor of the class,
-	 *                        that it should use to get instantiated with. Do not
-	 *                        include, if the constructor has no arguments.
+	 *                        that it should use to get instantiated with.
 	 * @return The instance of this class.
 	 */
 	public static Object newInstanceFromPrivateConstructor(Class<?> clazz, Object... constructorArgs) {
@@ -155,12 +149,29 @@ public final class ReflectionTestUtils {
 	 * @param constructor     The actual constructor that should be used for
 	 *                        creating a new instance of the object
 	 * @param constructorArgs Parameter instances of the constructor of the class,
-	 *                        that it should use to get instantiated with. Do not
-	 *                        include, if the constructor has no arguments.
+	 *                        that it should use to get instantiated with.
 	 * @return The instance of this class.
 	 */
 	public static Object newInstance(Constructor<?> constructor, Object... constructorArgs) {
 		return newInstanceAccessible(constructor, false, constructorArgs);
+	}
+
+	/**
+	 * Instantiate an object of a class by using a specific constructor and
+	 * constructor arguments, if applicable.
+	 * <p>
+	 * Forces the access to package-private, {@code protected}, and {@code private}
+	 * constructors. Use {@link #newInstance(Constructor, Object...)} if you do not
+	 * require this functionality.
+	 *
+	 * @param constructor     The actual constructor that should be used for
+	 *                        creating a new instance of the object
+	 * @param constructorArgs Parameter instances of the constructor of the class,
+	 *                        that it should use to get instantiated with.
+	 * @return The instance of this class.
+	 */
+	public static Object newInstanceFromPrivateConstructor(Constructor<?> constructor, Object... constructorArgs) {
+		return newInstanceAccessible(constructor, true, constructorArgs);
 	}
 
 	/**
@@ -293,8 +304,7 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param object         instance of the class that defines the method.
 	 * @param methodName     the name of the method.
-	 * @param parameterTypes The parameter types of this method. Do not include if
-	 *                       the method has no parameters.
+	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 */
 	public static Method getMethod(Object object, String methodName, Class<?>... parameterTypes) {
@@ -307,8 +317,7 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param declaringClass The class that declares this method.
 	 * @param methodName     The name of this method.
-	 * @param parameterTypes The parameter types of this method. Do not include if
-	 *                       the method has no parameters.
+	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 */
 	public static Method getMethod(Class<?> declaringClass, String methodName, Class<?>... parameterTypes) {
@@ -349,8 +358,7 @@ public final class ReflectionTestUtils {
 	 * @param object     The instance of the class that should invoke the method.
 	 *                   Must not be null, even for static methods.
 	 * @param methodName The method name that has to get invoked.
-	 * @param params     Parameter instances of the method. Do not include if the
-	 *                   method has no parameters.
+	 * @param params     Parameter instances of the method.
 	 * @return The return value of the method.
 	 */
 	public static Object invokeMethod(Object object, String methodName, Object... params) {
@@ -363,7 +371,8 @@ public final class ReflectionTestUtils {
 	 * <p>
 	 * This method does not support invoking static methods and passing null,
 	 * passing subclasses of the parameter types or invoking methods with primitive
-	 * parameters. Use {@link #invokeMethod(Object, Method, Object...)} for that.
+	 * parameters. Use {@link #invokePrivateMethod(Object, Method, Object...)} for
+	 * that.
 	 * <p>
 	 * Forces access to package-private, {@code protected}, and {@code private}
 	 * methods. Use {@link #invokeMethod(Object, String, Object...)} when invoking
@@ -372,8 +381,7 @@ public final class ReflectionTestUtils {
 	 * @param object     The instance of the class that should invoke the method.
 	 *                   Must not be null, even for static methods.
 	 * @param methodName The method name that has to get invoked.
-	 * @param params     Parameter instances of the method. Do not include if the
-	 *                   method has no parameters.
+	 * @param params     Parameter instances of the method.
 	 * @return The return value of the method.
 	 */
 	public static Object invokePrivateMethod(Object object, String methodName, Object... params) {
@@ -386,8 +394,7 @@ public final class ReflectionTestUtils {
 	 * @param object The instance of the class that should invoke the method. Can be
 	 *               null if the method is static.
 	 * @param method The method that has to get invoked.
-	 * @param params Parameter instances of the method. Do not include if the method
-	 *               has no parameters.
+	 * @param params Parameter instances of the method.
 	 * @return The return value of the method.
 	 */
 	public static Object invokeMethod(Object object, Method method, Object... params) {
@@ -404,8 +411,7 @@ public final class ReflectionTestUtils {
 	 * @param object The instance of the class that should invoke the method. Can be
 	 *               null if the method is static.
 	 * @param method The method that has to get invoked.
-	 * @param params Parameter instances of the method. Do not include if the method
-	 *               has no parameters.
+	 * @param params Parameter instances of the method.
 	 * @return The return value of the method.
 	 */
 	public static Object invokePrivateMethod(Object object, Method method, Object... params) {
@@ -459,8 +465,7 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param object The instance of the class that should invoke the method.
 	 * @param method The method that has to get invoked.
-	 * @param params Parameter instances of the method. Do not include if the method
-	 *               has no parameters.
+	 * @param params Parameter instances of the method.
 	 * @throws Throwable the exception that was caught and which will be rethrown
 	 * @return The return value of the method.
 	 */
@@ -478,8 +483,7 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param object The instance of the class that should invoke the method.
 	 * @param method The method that has to get invoked.
-	 * @param params Parameter instances of the method. Do not include if the method
-	 *               has no parameters.
+	 * @param params Parameter instances of the method.
 	 * @throws Throwable the exception that was caught and which will be rethrown
 	 * @return The return value of the method.
 	 */
@@ -530,8 +534,7 @@ public final class ReflectionTestUtils {
 	 * Retrieve a constructor with arguments of a given class.
 	 *
 	 * @param declaringClass The class that declares this constructor.
-	 * @param parameterTypes The parameter types of this method. Do not include if
-	 *                       the method has no parameters.
+	 * @param parameterTypes The parameter types of this method.
 	 * @param <T>            The type parameter of the constructor and class
 	 * @return The wanted method.
 	 */

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -284,7 +284,7 @@ public final class ReflectionTestUtils {
 	private static Object valueForAttribute(Object object, String attributeName, boolean forceAccess) {
 		requireNonNull(object, "reflection_test_utils.attribute_null", attributeName); //$NON-NLS-1$
 		try {
-			Field field = ClassMemberAccessor.getAttribute(object.getClass(), attributeName, forceAccess);
+			Field field = ClassMemberAccessor.getField(object.getClass(), attributeName, forceAccess);
 			if (forceAccess) {
 				field.setAccessible(true);
 			}

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -87,7 +87,8 @@ public final class ReflectionTestUtils {
 	 * <p>
 	 * This method does not support passing null, passing subclasses of the
 	 * parameter types or invoking constructors with primitive parameters. Use
-	 * {@link #newInstanceFromPrivateConstructor(Constructor, Object...)} for that.
+	 * {@link #newInstanceFromNonPublicConstructor(Constructor, Object...)} for
+	 * that.
 	 * <p>
 	 * Forces the access to package-private, {@code protected}, and {@code private}
 	 * constructors. Use {@link #newInstance(String, Object...)} if you do not
@@ -100,8 +101,8 @@ public final class ReflectionTestUtils {
 	 * @return The instance of this class.
 	 * @see #newInstance(Class, Object...)
 	 */
-	public static Object newInstanceFromPrivateConstructor(String qualifiedClassName, Object... constructorArgs) {
-		return newInstanceFromPrivateConstructor(getClazz(qualifiedClassName), constructorArgs);
+	public static Object newInstanceFromNonPublicConstructor(String qualifiedClassName, Object... constructorArgs) {
+		return newInstanceFromNonPublicConstructor(getClazz(qualifiedClassName), constructorArgs);
 	}
 
 	/**
@@ -138,7 +139,7 @@ public final class ReflectionTestUtils {
 	 *                        that it should use to get instantiated with.
 	 * @return The instance of this class.
 	 */
-	public static Object newInstanceFromPrivateConstructor(Class<?> clazz, Object... constructorArgs) {
+	public static Object newInstanceFromNonPublicConstructor(Class<?> clazz, Object... constructorArgs) {
 		return newInstanceAccessible(clazz, true, constructorArgs);
 	}
 
@@ -170,7 +171,7 @@ public final class ReflectionTestUtils {
 	 *                        that it should use to get instantiated with.
 	 * @return The instance of this class.
 	 */
-	public static Object newInstanceFromPrivateConstructor(Constructor<?> constructor, Object... constructorArgs) {
+	public static Object newInstanceFromNonPublicConstructor(Constructor<?> constructor, Object... constructorArgs) {
 		return newInstanceAccessible(constructor, true, constructorArgs);
 	}
 
@@ -266,7 +267,7 @@ public final class ReflectionTestUtils {
 	 *                      retrieved.
 	 * @return The instance of the attribute with the wanted value.
 	 */
-	public static Object valueForPrivateAttribute(Object object, String attributeName) {
+	public static Object valueForNonPublicAttribute(Object object, String attributeName) {
 		return valueForAttribute(object, attributeName, true);
 	}
 
@@ -329,15 +330,15 @@ public final class ReflectionTestUtils {
 	 *
 	 * @param declaringClass The class that declares this method.
 	 * @param methodName     The name of this method.
-	 * @param findPrivate    True, if this method should search for (package)
+	 * @param findNonPublic  True, if this method should search for (package)
 	 *                       private or protected methods.
 	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 */
-	private static Method getMethodAccessible(Class<?> declaringClass, String methodName, boolean findPrivate,
+	private static Method getMethodAccessible(Class<?> declaringClass, String methodName, boolean findNonPublic,
 			Class<?>[] parameterTypes) {
 		try {
-			return ClassMemberAccessor.getMethod(declaringClass, methodName, findPrivate, parameterTypes);
+			return ClassMemberAccessor.getMethod(declaringClass, methodName, findNonPublic, parameterTypes);
 		} catch (@SuppressWarnings("unused") NoSuchMethodException nsme) {
 			throw localizedFailure("reflection_test_utils.method_not_found", methodName, //$NON-NLS-1$
 					describeParameters(parameterTypes), declaringClass.getSimpleName());
@@ -371,7 +372,7 @@ public final class ReflectionTestUtils {
 	 * <p>
 	 * This method does not support invoking static methods and passing null,
 	 * passing subclasses of the parameter types or invoking methods with primitive
-	 * parameters. Use {@link #invokePrivateMethod(Object, Method, Object...)} for
+	 * parameters. Use {@link #invokeNonPublicMethod(Object, Method, Object...)} for
 	 * that.
 	 * <p>
 	 * Forces access to package-private, {@code protected}, and {@code private}
@@ -384,7 +385,7 @@ public final class ReflectionTestUtils {
 	 * @param params     Parameter instances of the method.
 	 * @return The return value of the method.
 	 */
-	public static Object invokePrivateMethod(Object object, String methodName, Object... params) {
+	public static Object invokeNonPublicMethod(Object object, String methodName, Object... params) {
 		return invokeMethodAccessible(object, methodName, true, params);
 	}
 
@@ -414,7 +415,7 @@ public final class ReflectionTestUtils {
 	 * @param params Parameter instances of the method.
 	 * @return The return value of the method.
 	 */
-	public static Object invokePrivateMethod(Object object, Method method, Object... params) {
+	public static Object invokeNonPublicMethod(Object object, Method method, Object... params) {
 		return invokeMethodAccessible(object, method, true, params);
 	}
 
@@ -487,7 +488,7 @@ public final class ReflectionTestUtils {
 	 * @throws Throwable the exception that was caught and which will be rethrown
 	 * @return The return value of the method.
 	 */
-	public static Object invokePrivateMethodRethrowing(Object object, Method method, Object... params)
+	public static Object invokeNonPublicMethodRethrowing(Object object, Method method, Object... params)
 			throws Throwable {
 		return invokeMethodRethrowingAccessible(object, method, true, params);
 	}

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -179,7 +179,7 @@ public final class ReflectionTestUtils {
 		var constructorArgTypes = getParameterTypes(constructorArgs, "reflection_test_utils.constructor_null_args", //$NON-NLS-1$
 				clazz.getSimpleName());
 		try {
-			Constructor<?> constructor = ClassMemberAccessor.getConstructor(clazz, forceAccess, constructorArgTypes);
+			Constructor<?> constructor = clazz.getDeclaredConstructor(constructorArgTypes);
 			return newInstanceAccessible(constructor, forceAccess, constructorArgs);
 		} catch (@SuppressWarnings("unused") NoSuchMethodException nsme) {
 			throw localizedFailure("reflection_test_utils.constructor_not_found_args", clazz.getSimpleName(), //$NON-NLS-1$
@@ -322,8 +322,7 @@ public final class ReflectionTestUtils {
 	 * @param methodName     The name of this method.
 	 * @param findPrivate    True, if this method should search for (package)
 	 *                       private or protected methods.
-	 * @param parameterTypes The parameter types of this method. Do not include if
-	 *                       the method has no parameters.
+	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 */
 	private static Method getMethodAccessible(Class<?> declaringClass, String methodName, boolean findPrivate,

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -540,7 +540,7 @@ public final class ReflectionTestUtils {
 	 */
 	public static <T> Constructor<T> getConstructor(Class<T> declaringClass, Class<?>... parameterTypes) {
 		try {
-			return declaringClass.getDeclaredConstructor(parameterTypes);
+			return declaringClass.getConstructor(parameterTypes);
 		} catch (@SuppressWarnings("unused") NoSuchMethodException nsme) {
 			throw localizedFailure("reflection_test_utils.constructor_not_found_params", //$NON-NLS-1$
 					describeParameters(parameterTypes), declaringClass.getSimpleName());

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -34,7 +34,7 @@ import org.opentest4j.AssertionFailedError;
  * </ul>
  *
  * @author Stephan Krusche (krusche@in.tum.de)
- * @version 5.1 (2022-03-30)
+ * @version 6.0 (2022-05-27)
  */
 @API(status = Status.STABLE)
 public final class ReflectionTestUtils {

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -312,8 +312,24 @@ public final class ReflectionTestUtils {
 	 * @return The wanted method.
 	 */
 	public static Method getMethod(Class<?> declaringClass, String methodName, Class<?>... parameterTypes) {
+		return getMethodAccessible(declaringClass, methodName, false, parameterTypes);
+	}
+
+	/**
+	 * Retrieve a method with arguments of a given class by its name.
+	 *
+	 * @param declaringClass The class that declares this method.
+	 * @param methodName     The name of this method.
+	 * @param findPrivate    True, if this method should search for (package)
+	 *                       private or protected methods.
+	 * @param parameterTypes The parameter types of this method. Do not include if
+	 *                       the method has no parameters.
+	 * @return The wanted method.
+	 */
+	private static Method getMethodAccessible(Class<?> declaringClass, String methodName, boolean findPrivate,
+			Class<?>[] parameterTypes) {
 		try {
-			return declaringClass.getDeclaredMethod(methodName, parameterTypes);
+			return ClassMemberAccessor.getMethod(declaringClass, methodName, findPrivate, parameterTypes);
 		} catch (@SuppressWarnings("unused") NoSuchMethodException nsme) {
 			throw localizedFailure("reflection_test_utils.method_not_found", methodName, //$NON-NLS-1$
 					describeParameters(parameterTypes), declaringClass.getSimpleName());
@@ -411,7 +427,7 @@ public final class ReflectionTestUtils {
 	private static Object invokeMethodAccessible(Object object, String methodName, boolean forceAccess,
 			Object[] params) {
 		var parameterTypes = getParameterTypes(params, "reflection_test_utils.method_null_args", methodName); //$NON-NLS-1$
-		var method = getMethod(object, methodName, parameterTypes);
+		var method = getMethodAccessible(object.getClass(), methodName, forceAccess, parameterTypes);
 		return invokeMethodAccessible(object, method, forceAccess, params);
 	}
 

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -13,19 +13,21 @@ import de.tum.in.test.integration.testuser.subject.structural.AbstractClassExten
 class ClassMemberAccessorTest {
 	@Test
 	void getProtectedInheritedMethod() throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "nonAbstractProtected", true);
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "nonAbstractProtected", true,
+				new Class[] {});
 		assertThat(method).isNotNull();
 	}
 
 	@Test
 	void getProtectedInheritedMethodNoForcedAccess() {
-		assertThrows(NoSuchMethodException.class,
-				() -> ClassMemberAccessor.getMethod(AbstractClassExtension.class, "nonAbstractProtected", false));
+		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(AbstractClassExtension.class,
+				"nonAbstractProtected", false, new Class[] {}));
 	}
 
 	@Test
 	void getMethodMatchingParameters() throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", true, int.class);
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", true,
+				new Class[] { int.class });
 		assertThat(Modifier.isPrivate(method.getModifiers())).isTrue();
 		assertThat(method.getParameterTypes()).containsExactly(int.class);
 	}

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -3,14 +3,36 @@ package de.tum.in.test.api.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import de.tum.in.test.integration.testuser.subject.structural.AbstractClassExtension;
+import de.tum.in.test.integration.testuser.subject.structural.SomeAbstractClass;
+import de.tum.in.test.integration.testuser.subject.structural.SomeInterface;
 
 class ClassMemberAccessorTest {
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getPublicMethod(boolean findPrivate) throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", findPrivate,
+				new Class[] {});
+		assertThat(method).isNotNull();
+	}
+
+	@Test
+	void getMethodMatchingParameters() throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", true,
+				new Class[] { int.class });
+		assertThat(Modifier.isPrivate(method.getModifiers())).isTrue();
+		assertThat(method.getParameterTypes()).containsExactly(int.class);
+	}
+
 	@Test
 	void getProtectedInheritedMethod() throws NoSuchMethodException {
 		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "nonAbstractProtected", true,
@@ -24,11 +46,51 @@ class ClassMemberAccessorTest {
 				"nonAbstractProtected", false, new Class[] {}));
 	}
 
-	@Test
-	void getMethodMatchingParameters() throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", true,
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getInheritedInterfaceDefaultMethod(boolean findPrivate) throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "doSomethingElse", findPrivate,
 				new Class[] { int.class });
-		assertThat(Modifier.isPrivate(method.getModifiers())).isTrue();
-		assertThat(method.getParameterTypes()).containsExactly(int.class);
+		assertThat(method.getDeclaringClass()).isEqualTo(SomeInterface.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getNonAccessiblePrivateSuperclassMethod(boolean findPrivate) {
+		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(AbstractClassExtension.class,
+				"nonAbstractPrivate", findPrivate, new Class[] {}));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getPublicInheritedAttribute(boolean findPrivate) throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someInt", findPrivate);
+		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
+	}
+
+	@Test
+	void getProtectedInheritedAttribute() throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", true);
+		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
+	}
+
+	@Test
+	void getProtectedInheritedAttributeNoForcedAccess() {
+		assertThrows(NoSuchFieldException.class,
+				() -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", false));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getInterfaceAttribute(boolean findPrivate) throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "ANOTHER_CONSTANT", findPrivate);
+		assertThat(field.getDeclaringClass()).isEqualTo(SomeInterface.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getNonAccessiblePrivateSuperclassField(boolean findPrivate) {
+		assertThrows(NoSuchFieldException.class, () -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class,
+				"somePrivateAttribute", findPrivate));
 	}
 }

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -14,15 +14,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 import de.tum.in.test.integration.testuser.subject.structural.AbstractClassExtension;
 import de.tum.in.test.integration.testuser.subject.structural.SomeAbstractClass;
 import de.tum.in.test.integration.testuser.subject.structural.SomeInterface;
+import de.tum.in.test.integration.testuser.subject.structural.subpackage.SubpackageClass;
 
 class ClassMemberAccessorTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getPublicMethod(boolean findPrivate) throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", findPrivate,
-				new Class[] {});
-		assertThat(method).isNotNull();
+	void getInheritedInterfaceDefaultMethod(boolean findPrivate) throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "doSomethingElse", findPrivate,
+				new Class[] { int.class });
+		assertThat(method.getDeclaringClass()).isEqualTo(SomeInterface.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getInterfaceAttribute(boolean findPrivate) throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "ANOTHER_CONSTANT", findPrivate);
+		assertThat(field.getDeclaringClass()).isEqualTo(SomeInterface.class);
 	}
 
 	@Test
@@ -31,6 +39,39 @@ class ClassMemberAccessorTest {
 				new Class[] { int.class });
 		assertThat(Modifier.isPrivate(method.getModifiers())).isTrue();
 		assertThat(method.getParameterTypes()).containsExactly(int.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getNonAccessiblePrivateSuperclassField(boolean findPrivate) {
+		assertThrows(NoSuchFieldException.class, () -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class,
+				"somePrivateAttribute", findPrivate));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getNonAccessiblePrivateSuperclassMethod(boolean findPrivate) {
+		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(AbstractClassExtension.class,
+				"nonAbstractPrivate", findPrivate, new Class[] {}));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getPackagePrivateMethodNoAccessInSubpackage(boolean findPrivate) {
+		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(SubpackageClass.class,
+				"nonAbstractPackagePrivate", findPrivate, new Class[] {}));
+	}
+
+	@Test
+	void getProtectedInheritedAttribute() throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", true);
+		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
+	}
+
+	@Test
+	void getProtectedInheritedAttributeNoForcedAccess() {
+		assertThrows(NoSuchFieldException.class,
+				() -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", false));
 	}
 
 	@Test
@@ -46,19 +87,11 @@ class ClassMemberAccessorTest {
 				"nonAbstractProtected", false, new Class[] {}));
 	}
 
-	@ParameterizedTest
-	@ValueSource(booleans = { true, false })
-	void getInheritedInterfaceDefaultMethod(boolean findPrivate) throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "doSomethingElse", findPrivate,
-				new Class[] { int.class });
-		assertThat(method.getDeclaringClass()).isEqualTo(SomeInterface.class);
-	}
-
-	@ParameterizedTest
-	@ValueSource(booleans = { true, false })
-	void getNonAccessiblePrivateSuperclassMethod(boolean findPrivate) {
-		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(AbstractClassExtension.class,
-				"nonAbstractPrivate", findPrivate, new Class[] {}));
+	@Test
+	void getProtectedMethodAccessInSubpackage() throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(SubpackageClass.class, "nonAbstractProtected", true,
+				new Class[] {});
+		assertThat(method).isNotNull();
 	}
 
 	@ParameterizedTest
@@ -68,29 +101,11 @@ class ClassMemberAccessorTest {
 		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
 	}
 
-	@Test
-	void getProtectedInheritedAttribute() throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", true);
-		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
-	}
-
-	@Test
-	void getProtectedInheritedAttributeNoForcedAccess() {
-		assertThrows(NoSuchFieldException.class,
-				() -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", false));
-	}
-
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getInterfaceAttribute(boolean findPrivate) throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "ANOTHER_CONSTANT", findPrivate);
-		assertThat(field.getDeclaringClass()).isEqualTo(SomeInterface.class);
-	}
-
-	@ParameterizedTest
-	@ValueSource(booleans = { true, false })
-	void getNonAccessiblePrivateSuperclassField(boolean findPrivate) {
-		assertThrows(NoSuchFieldException.class, () -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class,
-				"somePrivateAttribute", findPrivate));
+	void getPublicMethod(boolean findPrivate) throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", findPrivate,
+				new Class[] {});
+		assertThat(method).isNotNull();
 	}
 }

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -1,0 +1,32 @@
+package de.tum.in.test.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.in.test.integration.testuser.subject.structural.AbstractClassExtension;
+
+class ClassMemberAccessorTest {
+	@Test
+	void getProtectedInheritedMethod() throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "nonAbstractProtected", true);
+		assertThat(method).isNotNull();
+	}
+
+	@Test
+	void getProtectedInheritedMethodNoForcedAccess() {
+		assertThrows(NoSuchMethodException.class,
+				() -> ClassMemberAccessor.getMethod(AbstractClassExtension.class, "nonAbstractProtected", false));
+	}
+
+	@Test
+	void getMethodMatchingParameters() throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", true, int.class);
+		assertThat(Modifier.isPrivate(method.getModifiers())).isTrue();
+		assertThat(method.getParameterTypes()).containsExactly(int.class);
+	}
+}

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import de.tum.in.test.integration.testuser.subject.structural.AbstractClassExtension;
 import de.tum.in.test.integration.testuser.subject.structural.SomeAbstractClass;
+import de.tum.in.test.integration.testuser.subject.structural.SomeClass;
 import de.tum.in.test.integration.testuser.subject.structural.SomeInterface;
 import de.tum.in.test.integration.testuser.subject.structural.subpackage.SubpackageClass;
 
@@ -29,7 +30,7 @@ class ClassMemberAccessorTest {
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
 	void getInterfaceAttribute(boolean findPrivate) throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "ANOTHER_CONSTANT", findPrivate);
+		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "ANOTHER_CONSTANT", findPrivate);
 		assertThat(field.getDeclaringClass()).isEqualTo(SomeInterface.class);
 	}
 
@@ -44,8 +45,8 @@ class ClassMemberAccessorTest {
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
 	void getNonAccessiblePrivateSuperclassField(boolean findPrivate) {
-		assertThrows(NoSuchFieldException.class, () -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class,
-				"somePrivateAttribute", findPrivate));
+		assertThrows(NoSuchFieldException.class,
+				() -> ClassMemberAccessor.getField(AbstractClassExtension.class, "somePrivateAttribute", findPrivate));
 	}
 
 	@ParameterizedTest
@@ -64,14 +65,14 @@ class ClassMemberAccessorTest {
 
 	@Test
 	void getProtectedInheritedAttribute() throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", true);
+		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "someProtectedAttribute", true);
 		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
 	}
 
 	@Test
 	void getProtectedInheritedAttributeNoForcedAccess() {
 		assertThrows(NoSuchFieldException.class,
-				() -> ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someProtectedAttribute", false));
+				() -> ClassMemberAccessor.getField(AbstractClassExtension.class, "someProtectedAttribute", false));
 	}
 
 	@Test
@@ -97,7 +98,7 @@ class ClassMemberAccessorTest {
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
 	void getPublicInheritedAttribute(boolean findPrivate) throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getAttribute(AbstractClassExtension.class, "someInt", findPrivate);
+		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "someInt", findPrivate);
 		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
 	}
 
@@ -107,5 +108,12 @@ class ClassMemberAccessorTest {
 		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", findPrivate,
 				new Class[] {});
 		assertThat(method).isNotNull();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void getStaticMethodFromInterface(boolean findPrivate) {
+		assertThrows(NoSuchMethodException.class,
+				() -> ClassMemberAccessor.getMethod(SomeClass.class, "getOne", findPrivate, new Class[] {}));
 	}
 }

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -21,16 +21,16 @@ class ClassMemberAccessorTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getInheritedInterfaceDefaultMethod(boolean findPrivate) throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "doSomethingElse", findPrivate,
+	void getInheritedInterfaceDefaultMethod(boolean findNonPublic) throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "doSomethingElse", findNonPublic,
 				new Class[] { int.class });
 		assertThat(method.getDeclaringClass()).isEqualTo(SomeInterface.class);
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getInterfaceAttribute(boolean findPrivate) throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "ANOTHER_CONSTANT", findPrivate);
+	void getInterfaceAttribute(boolean findNonPublic) throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "ANOTHER_CONSTANT", findNonPublic);
 		assertThat(field.getDeclaringClass()).isEqualTo(SomeInterface.class);
 	}
 
@@ -44,23 +44,23 @@ class ClassMemberAccessorTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getNonAccessiblePrivateSuperclassField(boolean findPrivate) {
-		assertThrows(NoSuchFieldException.class,
-				() -> ClassMemberAccessor.getField(AbstractClassExtension.class, "somePrivateAttribute", findPrivate));
+	void getNonAccessiblePrivateSuperclassField(boolean findNonPublic) {
+		assertThrows(NoSuchFieldException.class, () -> ClassMemberAccessor.getField(AbstractClassExtension.class,
+				"somePrivateAttribute", findNonPublic));
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getNonAccessiblePrivateSuperclassMethod(boolean findPrivate) {
+	void getNonAccessiblePrivateSuperclassMethod(boolean findNonPublic) {
 		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(AbstractClassExtension.class,
-				"nonAbstractPrivate", findPrivate, new Class[] {}));
+				"nonAbstractPrivate", findNonPublic, new Class[] {}));
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getPackagePrivateMethodNoAccessInSubpackage(boolean findPrivate) {
+	void getPackagePrivateMethodNoAccessInSubpackage(boolean findNonPublic) {
 		assertThrows(NoSuchMethodException.class, () -> ClassMemberAccessor.getMethod(SubpackageClass.class,
-				"nonAbstractPackagePrivate", findPrivate, new Class[] {}));
+				"nonAbstractPackagePrivate", findNonPublic, new Class[] {}));
 	}
 
 	@Test
@@ -97,23 +97,23 @@ class ClassMemberAccessorTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getPublicInheritedAttribute(boolean findPrivate) throws NoSuchFieldException {
-		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "someInt", findPrivate);
+	void getPublicInheritedAttribute(boolean findNonPublic) throws NoSuchFieldException {
+		Field field = ClassMemberAccessor.getField(AbstractClassExtension.class, "someInt", findNonPublic);
 		assertThat(field.getDeclaringClass()).isEqualTo(SomeAbstractClass.class);
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getPublicMethod(boolean findPrivate) throws NoSuchMethodException {
-		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", findPrivate,
+	void getPublicMethod(boolean findNonPublic) throws NoSuchMethodException {
+		Method method = ClassMemberAccessor.getMethod(AbstractClassExtension.class, "declaredMethod", findNonPublic,
 				new Class[] {});
 		assertThat(method).isNotNull();
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = { true, false })
-	void getStaticMethodFromInterface(boolean findPrivate) {
+	void getStaticMethodFromInterface(boolean findNonPublic) {
 		assertThrows(NoSuchMethodException.class,
-				() -> ClassMemberAccessor.getMethod(SomeClass.class, "getOne", findPrivate, new Class[] {}));
+				() -> ClassMemberAccessor.getMethod(SomeClass.class, "getOne", findNonPublic, new Class[] {}));
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/DynamicsTest.java
+++ b/src/test/java/de/tum/in/test/integration/DynamicsTest.java
@@ -89,7 +89,7 @@ class DynamicsTest {
 	@TestTest
 	void test_class_searchPublicOrProtectedMethods() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(class_searchPublicOrProtectedMethods,
-				AssertionFailedError.class, "Methode doSomething(java.lang.String) darf nicht public sein."));
+				AssertionFailedError.class, "Methode nonAbstractProtected() darf nicht protected sein."));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/in/test/integration/ReflectionTestUtilsTest.java
+++ b/src/test/java/de/tum/in/test/integration/ReflectionTestUtilsTest.java
@@ -24,24 +24,33 @@ class ReflectionTestUtilsTest {
 	private final String testGetMethod_success = "testGetMethod_success";
 	private final String testInvokeMethod_invocationTarget = "testInvokeMethod_invocationTarget";
 	private final String testInvokeMethod_success = "testInvokeMethod_success";
+	private final String testInvokePrivateMethodByName_success = "testInvokePrivateMethodByName_success";
 	private final String testInvokeMethodRethrowing_illegalAccess = "testInvokeMethodRethrowing_illegalAccess";
+	private final String testInvokePrivateMethodRethrowing_success = "testInvokePrivateMethodRethrowing_success";
 	private final String testInvokeMethodRethrowing_illegalArgument = "testInvokeMethodRethrowing_illegalArgument";
 	private final String testInvokeMethodRethrowing_nullPointer = "testInvokeMethodRethrowing_nullPointer";
 	private final String testNewInstance_classNotFound = "testNewInstance_classNotFound";
 	private final String testNewInstance_exceptionInInitializer = "testNewInstance_exceptionInInitializer";
 	private final String testNewInstance_illegalAccess = "testNewInstance_illegalAccess";
+	private final String testNewInstancePrivateConstructor_success = "testNewInstancePrivateConstructor_success";
 	private final String testNewInstance_illegalArguments = "testNewInstance_illegalArguments";
 	private final String testNewInstance_instantiation = "testNewInstance_instantiation";
 	private final String testNewInstance_invocationTarget = "testNewInstance_invocationTarget";
 	private final String testNewInstance_noSuchMethod = "testNewInstance_noSuchMethod";
 	private final String testNewInstance_success = "testNewInstance_success";
 	private final String testValueForAttribute_illegalAccess = "testValueForAttribute_illegalAccess";
+	private final String testValueForPrivateAttribute_success = "testValueForPrivateAttribute_success";
 	private final String testValueForAttribute_noSuchField = "testValueForAttribute_noSuchField";
 	private final String testValueForAttribute_success = "testValueForAttribute_success";
 
 	@TestTest
 	void test_invokeMethod_success() {
 		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testInvokeMethod_success));
+	}
+
+	@TestTest
+	void test_invokePrivateMethodByName_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testInvokePrivateMethodByName_success));
 	}
 
 	@TestTest
@@ -96,6 +105,11 @@ class ReflectionTestUtilsTest {
 	}
 
 	@TestTest
+	void test_testInvokePrivateMethodRethrowing_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testInvokePrivateMethodRethrowing_success));
+	}
+
+	@TestTest
 	void test_testInvokeMethodRethrowing_illegalArgument() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethodRethrowing_illegalArgument,
 				AssertionFailedError.class,
@@ -128,6 +142,11 @@ class ReflectionTestUtilsTest {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testNewInstance_illegalAccess,
 				AssertionFailedError.class,
 				"Could not instantiate the class SomeClass because access to its constructor with the parameters: [ String ] was denied. Make sure to check the modifiers of the constructor."));
+	}
+
+	@TestTest
+	void test_testNewInstancePrivateConstructor_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testNewInstancePrivateConstructor_success));
 	}
 
 	@TestTest
@@ -167,6 +186,11 @@ class ReflectionTestUtilsTest {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testValueForAttribute_illegalAccess,
 				AssertionFailedError.class,
 				"Could not retrieve the attribute 'someAttribute' from the class SomeClass because access to the attribute was denied. Make sure to check the modifiers of the attribute."));
+	}
+
+	@TestTest
+	void test_testValueForPrivateAttribute_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testValueForPrivateAttribute_success));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/in/test/integration/ReflectionTestUtilsTest.java
+++ b/src/test/java/de/tum/in/test/integration/ReflectionTestUtilsTest.java
@@ -22,26 +22,26 @@ class ReflectionTestUtilsTest {
 	private final String testGetMethod_noSuchMethod_noParameters = "testGetMethod_noSuchMethod_noParameters";
 	private final String testGetMethod_noSuchMethod_withParameters = "testGetMethod_noSuchMethod_withParameters";
 	private final String testGetMethod_success = "testGetMethod_success";
+	private final String testInvokeMethodRethrowing_illegalAccess = "testInvokeMethodRethrowing_illegalAccess";
+	private final String testInvokeMethodRethrowing_illegalArgument = "testInvokeMethodRethrowing_illegalArgument";
+	private final String testInvokeMethodRethrowing_nullPointer = "testInvokeMethodRethrowing_nullPointer";
 	private final String testInvokeMethod_invocationTarget = "testInvokeMethod_invocationTarget";
 	private final String testInvokeMethod_success = "testInvokeMethod_success";
 	private final String testInvokePrivateMethodByName_success = "testInvokePrivateMethodByName_success";
-	private final String testInvokeMethodRethrowing_illegalAccess = "testInvokeMethodRethrowing_illegalAccess";
 	private final String testInvokePrivateMethodRethrowing_success = "testInvokePrivateMethodRethrowing_success";
-	private final String testInvokeMethodRethrowing_illegalArgument = "testInvokeMethodRethrowing_illegalArgument";
-	private final String testInvokeMethodRethrowing_nullPointer = "testInvokeMethodRethrowing_nullPointer";
+	private final String testNewInstancePrivateConstructor_success = "testNewInstancePrivateConstructor_success";
 	private final String testNewInstance_classNotFound = "testNewInstance_classNotFound";
 	private final String testNewInstance_exceptionInInitializer = "testNewInstance_exceptionInInitializer";
 	private final String testNewInstance_illegalAccess = "testNewInstance_illegalAccess";
-	private final String testNewInstancePrivateConstructor_success = "testNewInstancePrivateConstructor_success";
 	private final String testNewInstance_illegalArguments = "testNewInstance_illegalArguments";
 	private final String testNewInstance_instantiation = "testNewInstance_instantiation";
 	private final String testNewInstance_invocationTarget = "testNewInstance_invocationTarget";
 	private final String testNewInstance_noSuchMethod = "testNewInstance_noSuchMethod";
 	private final String testNewInstance_success = "testNewInstance_success";
 	private final String testValueForAttribute_illegalAccess = "testValueForAttribute_illegalAccess";
-	private final String testValueForPrivateAttribute_success = "testValueForPrivateAttribute_success";
 	private final String testValueForAttribute_noSuchField = "testValueForAttribute_noSuchField";
 	private final String testValueForAttribute_success = "testValueForAttribute_success";
+	private final String testValueForPrivateAttribute_success = "testValueForPrivateAttribute_success";
 
 	@TestTest
 	void test_invokeMethod_success() {
@@ -91,22 +91,10 @@ class ReflectionTestUtilsTest {
 	}
 
 	@TestTest
-	void test_testInvokeMethod_invocationTarget() {
-		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethod_invocationTarget,
-				AssertionFailedError.class,
-				"Could not invoke the method 'throwException' in the class SomeClass because of an exception within the method: java.lang.RuntimeException"));
-	}
-
-	@TestTest
 	void test_testInvokeMethodRethrowing_illegalAccess() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethodRethrowing_illegalAccess,
 				AssertionFailedError.class,
 				"Could not invoke the method 'superSecretMethod' in the class SomeClass because access to the method was denied. Make sure to check the modifiers of the method."));
-	}
-
-	@TestTest
-	void test_testInvokePrivateMethodRethrowing_success() {
-		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testInvokePrivateMethodRethrowing_success));
 	}
 
 	@TestTest
@@ -121,6 +109,23 @@ class ReflectionTestUtilsTest {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethodRethrowing_nullPointer,
 				AssertionFailedError.class,
 				"Could not invoke the method 'getAnotherAttribute' in the class SomeClass because the object was null and the method is an instance method. Make sure to check the static modifier of the method."));
+	}
+
+	@TestTest
+	void test_testInvokeMethod_invocationTarget() {
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethod_invocationTarget,
+				AssertionFailedError.class,
+				"Could not invoke the method 'throwException' in the class SomeClass because of an exception within the method: java.lang.RuntimeException"));
+	}
+
+	@TestTest
+	void test_testInvokePrivateMethodRethrowing_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testInvokePrivateMethodRethrowing_success));
+	}
+
+	@TestTest
+	void test_testNewInstancePrivateConstructor_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testNewInstancePrivateConstructor_success));
 	}
 
 	@TestTest
@@ -142,11 +147,6 @@ class ReflectionTestUtilsTest {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testNewInstance_illegalAccess,
 				AssertionFailedError.class,
 				"Could not instantiate the class SomeClass because access to its constructor with the parameters: [ String ] was denied. Make sure to check the modifiers of the constructor."));
-	}
-
-	@TestTest
-	void test_testNewInstancePrivateConstructor_success() {
-		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testNewInstancePrivateConstructor_success));
 	}
 
 	@TestTest
@@ -189,11 +189,6 @@ class ReflectionTestUtilsTest {
 	}
 
 	@TestTest
-	void test_testValueForPrivateAttribute_success() {
-		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testValueForPrivateAttribute_success));
-	}
-
-	@TestTest
 	void test_testValueForAttribute_noSuchField() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testValueForAttribute_noSuchField,
 				AssertionFailedError.class,
@@ -203,5 +198,10 @@ class ReflectionTestUtilsTest {
 	@TestTest
 	void test_testValueForAttribute_success() {
 		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testValueForAttribute_success));
+	}
+
+	@TestTest
+	void test_testValueForPrivateAttribute_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testValueForPrivateAttribute_success));
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/ReflectionTestUtilsTest.java
+++ b/src/test/java/de/tum/in/test/integration/ReflectionTestUtilsTest.java
@@ -22,14 +22,13 @@ class ReflectionTestUtilsTest {
 	private final String testGetMethod_noSuchMethod_noParameters = "testGetMethod_noSuchMethod_noParameters";
 	private final String testGetMethod_noSuchMethod_withParameters = "testGetMethod_noSuchMethod_withParameters";
 	private final String testGetMethod_success = "testGetMethod_success";
+	private final String testInvokeMethod_invocationTarget = "testInvokeMethod_invocationTarget";
+	private final String testInvokeMethod_success = "testInvokeMethod_success";
 	private final String testInvokeMethodRethrowing_illegalAccess = "testInvokeMethodRethrowing_illegalAccess";
 	private final String testInvokeMethodRethrowing_illegalArgument = "testInvokeMethodRethrowing_illegalArgument";
 	private final String testInvokeMethodRethrowing_nullPointer = "testInvokeMethodRethrowing_nullPointer";
-	private final String testInvokeMethod_invocationTarget = "testInvokeMethod_invocationTarget";
-	private final String testInvokeMethod_success = "testInvokeMethod_success";
 	private final String testInvokePrivateMethodByName_success = "testInvokePrivateMethodByName_success";
 	private final String testInvokePrivateMethodRethrowing_success = "testInvokePrivateMethodRethrowing_success";
-	private final String testNewInstancePrivateConstructor_success = "testNewInstancePrivateConstructor_success";
 	private final String testNewInstance_classNotFound = "testNewInstance_classNotFound";
 	private final String testNewInstance_exceptionInInitializer = "testNewInstance_exceptionInInitializer";
 	private final String testNewInstance_illegalAccess = "testNewInstance_illegalAccess";
@@ -38,6 +37,7 @@ class ReflectionTestUtilsTest {
 	private final String testNewInstance_invocationTarget = "testNewInstance_invocationTarget";
 	private final String testNewInstance_noSuchMethod = "testNewInstance_noSuchMethod";
 	private final String testNewInstance_success = "testNewInstance_success";
+	private final String testNewInstancePrivateConstructor_success = "testNewInstancePrivateConstructor_success";
 	private final String testValueForAttribute_illegalAccess = "testValueForAttribute_illegalAccess";
 	private final String testValueForAttribute_noSuchField = "testValueForAttribute_noSuchField";
 	private final String testValueForAttribute_success = "testValueForAttribute_success";
@@ -91,6 +91,13 @@ class ReflectionTestUtilsTest {
 	}
 
 	@TestTest
+	void test_testInvokeMethod_invocationTarget() {
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethod_invocationTarget,
+				AssertionFailedError.class,
+				"Could not invoke the method 'throwException' in the class SomeClass because of an exception within the method: java.lang.RuntimeException"));
+	}
+
+	@TestTest
 	void test_testInvokeMethodRethrowing_illegalAccess() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethodRethrowing_illegalAccess,
 				AssertionFailedError.class,
@@ -112,20 +119,8 @@ class ReflectionTestUtilsTest {
 	}
 
 	@TestTest
-	void test_testInvokeMethod_invocationTarget() {
-		tests.assertThatEvents().haveExactly(1, testFailedWith(testInvokeMethod_invocationTarget,
-				AssertionFailedError.class,
-				"Could not invoke the method 'throwException' in the class SomeClass because of an exception within the method: java.lang.RuntimeException"));
-	}
-
-	@TestTest
 	void test_testInvokePrivateMethodRethrowing_success() {
 		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testInvokePrivateMethodRethrowing_success));
-	}
-
-	@TestTest
-	void test_testNewInstancePrivateConstructor_success() {
-		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testNewInstancePrivateConstructor_success));
 	}
 
 	@TestTest
@@ -179,6 +174,11 @@ class ReflectionTestUtilsTest {
 	@TestTest
 	void test_testNewInstance_success() {
 		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testNewInstance_success));
+	}
+
+	@TestTest
+	void test_testNewInstancePrivateConstructor_success() {
+		tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testNewInstancePrivateConstructor_success));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -60,6 +60,17 @@ public class ReflectionTestUtilsUser {
 	}
 
 	@Test
+	void testInvokeMethod_invocationTarget() {
+		invokeMethod(CLASS_INSTANCE, "throwException");
+	}
+
+	@Test
+	void testInvokeMethod_success() {
+		var returnValue = invokeMethod(CLASS_INSTANCE, "getAnotherAttribute");
+		assertThat(returnValue).isEqualTo(CLASS_INSTANCE.getAnotherAttribute());
+	}
+
+	@Test
 	void testInvokeMethodRethrowing_illegalAccess() throws NoSuchMethodException {
 		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
 		invokeMethod(CLASS_INSTANCE, privateMethod);
@@ -78,17 +89,6 @@ public class ReflectionTestUtilsUser {
 	}
 
 	@Test
-	void testInvokeMethod_invocationTarget() {
-		invokeMethod(CLASS_INSTANCE, "throwException");
-	}
-
-	@Test
-	void testInvokeMethod_success() {
-		var returnValue = invokeMethod(CLASS_INSTANCE, "getAnotherAttribute");
-		assertThat(returnValue).isEqualTo(CLASS_INSTANCE.getAnotherAttribute());
-	}
-
-	@Test
 	void testInvokePrivateMethodByName_success() {
 		invokePrivateMethod(CLASS_INSTANCE, "superSecretMethod");
 	}
@@ -97,11 +97,6 @@ public class ReflectionTestUtilsUser {
 	void testInvokePrivateMethodRethrowing_success() throws NoSuchMethodException {
 		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
 		invokePrivateMethod(CLASS_INSTANCE, privateMethod);
-	}
-
-	@Test
-	void testNewInstancePrivateConstructor_success() {
-		newInstanceFromPrivateConstructor(CLASS_NAME, "");
 	}
 
 	@Test
@@ -144,6 +139,11 @@ public class ReflectionTestUtilsUser {
 	void testNewInstance_success() {
 		var instance = newInstance(CLASS_NAME, 1);
 		assertThat(instance).isInstanceOf(SomeClass.class);
+	}
+
+	@Test
+	void testNewInstancePrivateConstructor_success() {
+		newInstanceFromPrivateConstructor(CLASS_NAME, "");
 	}
 
 	@Test

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -71,9 +71,20 @@ public class ReflectionTestUtilsUser {
 	}
 
 	@Test
+	void testInvokePrivateMethodByName_success() {
+		invokePrivateMethod(CLASS_INSTANCE, "superSecretMethod");
+	}
+
+	@Test
 	void testInvokeMethodRethrowing_illegalAccess() throws NoSuchMethodException {
 		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
 		invokeMethod(CLASS_INSTANCE, privateMethod);
+	}
+
+	@Test
+	void testInvokePrivateMethodRethrowing_success() throws NoSuchMethodException {
+		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
+		invokePrivateMethod(CLASS_INSTANCE, privateMethod);
 	}
 
 	@Test
@@ -101,6 +112,11 @@ public class ReflectionTestUtilsUser {
 	@Test
 	void testNewInstance_illegalAccess() {
 		newInstance(CLASS_NAME, "");
+	}
+
+	@Test
+	void testNewInstancePrivateConstructor_success() {
+		newInstanceFromPrivateConstructor(CLASS_NAME, "");
 	}
 
 	@Test
@@ -133,6 +149,11 @@ public class ReflectionTestUtilsUser {
 	@Test
 	void testValueForAttribute_illegalAccess() {
 		valueForAttribute(CLASS_INSTANCE, "someAttribute");
+	}
+
+	@Test
+	void testValueForPrivateAttribute_success() {
+		valueForPrivateAttribute(CLASS_INSTANCE, "someAttribute");
 	}
 
 	@Test

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -90,13 +90,13 @@ public class ReflectionTestUtilsUser {
 
 	@Test
 	void testInvokePrivateMethodByName_success() {
-		invokePrivateMethod(CLASS_INSTANCE, "superSecretMethod");
+		invokeNonPublicMethod(CLASS_INSTANCE, "superSecretMethod");
 	}
 
 	@Test
 	void testInvokePrivateMethodRethrowing_success() throws NoSuchMethodException {
 		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
-		invokePrivateMethod(CLASS_INSTANCE, privateMethod);
+		invokeNonPublicMethod(CLASS_INSTANCE, privateMethod);
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class ReflectionTestUtilsUser {
 
 	@Test
 	void testNewInstancePrivateConstructor_success() {
-		newInstanceFromPrivateConstructor(CLASS_NAME, "");
+		newInstanceFromNonPublicConstructor(CLASS_NAME, "");
 	}
 
 	@Test
@@ -164,6 +164,6 @@ public class ReflectionTestUtilsUser {
 
 	@Test
 	void testValueForPrivateAttribute_success() {
-		valueForPrivateAttribute(CLASS_INSTANCE, "someAttribute");
+		valueForNonPublicAttribute(CLASS_INSTANCE, "someAttribute");
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -44,19 +44,37 @@ public class ReflectionTestUtilsUser {
 	}
 
 	@Test
-	void testGetMethod_noSuchMethod_withParameters() {
-		getMethod(CLASS_INSTANCE, "someMethod", String.class);
+	void testGetMethod_noSuchMethod_noParameters() {
+		getMethod(CLASS_INSTANCE, "someMethod");
 	}
 
 	@Test
-	void testGetMethod_noSuchMethod_noParameters() {
-		getMethod(CLASS_INSTANCE, "someMethod");
+	void testGetMethod_noSuchMethod_withParameters() {
+		getMethod(CLASS_INSTANCE, "someMethod", String.class);
 	}
 
 	@Test
 	void testGetMethod_success() {
 		var method = getMethod(CLASS_INSTANCE, "getAnotherAttribute");
 		assertThat(method).isInstanceOf(Method.class);
+	}
+
+	@Test
+	void testInvokeMethodRethrowing_illegalAccess() throws NoSuchMethodException {
+		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
+		invokeMethod(CLASS_INSTANCE, privateMethod);
+	}
+
+	@Test
+	void testInvokeMethodRethrowing_illegalArgument() throws NoSuchMethodException {
+		var method = CLASS_INSTANCE.getClass().getMethod("getAnotherAttribute");
+		invokeMethod(CLASS_INSTANCE, method, "Illegal");
+	}
+
+	@Test
+	void testInvokeMethodRethrowing_nullPointer() throws NoSuchMethodException {
+		var method = CLASS_INSTANCE.getClass().getMethod("getAnotherAttribute");
+		invokeMethod(null, method);
 	}
 
 	@Test
@@ -76,27 +94,14 @@ public class ReflectionTestUtilsUser {
 	}
 
 	@Test
-	void testInvokeMethodRethrowing_illegalAccess() throws NoSuchMethodException {
-		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
-		invokeMethod(CLASS_INSTANCE, privateMethod);
-	}
-
-	@Test
 	void testInvokePrivateMethodRethrowing_success() throws NoSuchMethodException {
 		var privateMethod = CLASS_INSTANCE.getClass().getDeclaredMethod("superSecretMethod");
 		invokePrivateMethod(CLASS_INSTANCE, privateMethod);
 	}
 
 	@Test
-	void testInvokeMethodRethrowing_illegalArgument() throws NoSuchMethodException {
-		var method = CLASS_INSTANCE.getClass().getMethod("getAnotherAttribute");
-		invokeMethod(CLASS_INSTANCE, method, "Illegal");
-	}
-
-	@Test
-	void testInvokeMethodRethrowing_nullPointer() throws NoSuchMethodException {
-		var method = CLASS_INSTANCE.getClass().getMethod("getAnotherAttribute");
-		invokeMethod(null, method);
+	void testNewInstancePrivateConstructor_success() {
+		newInstanceFromPrivateConstructor(CLASS_NAME, "");
 	}
 
 	@Test
@@ -112,11 +117,6 @@ public class ReflectionTestUtilsUser {
 	@Test
 	void testNewInstance_illegalAccess() {
 		newInstance(CLASS_NAME, "");
-	}
-
-	@Test
-	void testNewInstancePrivateConstructor_success() {
-		newInstanceFromPrivateConstructor(CLASS_NAME, "");
 	}
 
 	@Test
@@ -152,11 +152,6 @@ public class ReflectionTestUtilsUser {
 	}
 
 	@Test
-	void testValueForPrivateAttribute_success() {
-		valueForPrivateAttribute(CLASS_INSTANCE, "someAttribute");
-	}
-
-	@Test
 	void testValueForAttribute_noSuchField() {
 		valueForAttribute(CLASS_INSTANCE, "noSuchField");
 	}
@@ -165,5 +160,10 @@ public class ReflectionTestUtilsUser {
 	void testValueForAttribute_success() {
 		var value = valueForAttribute(CLASS_INSTANCE, "SOME_CONSTANT");
 		assertThat(value).isEqualTo(SomeClass.SOME_CONSTANT);
+	}
+
+	@Test
+	void testValueForPrivateAttribute_success() {
+		valueForPrivateAttribute(CLASS_INSTANCE, "someAttribute");
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/AbstractClassExtension.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/AbstractClassExtension.java
@@ -6,7 +6,6 @@ public class AbstractClassExtension extends SomeAbstractClass implements SomeInt
 		// nothing
 	}
 
-	@SuppressWarnings("unused")
 	public void declaredMethod() {
 		// nothing
 	}

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/AbstractClassExtension.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/AbstractClassExtension.java
@@ -1,0 +1,22 @@
+package de.tum.in.test.integration.testuser.subject.structural;
+
+public class AbstractClassExtension extends SomeAbstractClass {
+	@Override
+	void doNothing() {
+		// nothing
+	}
+
+	public void declaredMethod() {
+		// nothing
+	}
+
+	@SuppressWarnings("unused")
+	private void declaredMethod(int x) {
+		// nothing
+	}
+
+	@SuppressWarnings("unused")
+	private void declaredMethod(String s) {
+		// nothing
+	}
+}

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/AbstractClassExtension.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/AbstractClassExtension.java
@@ -1,11 +1,12 @@
 package de.tum.in.test.integration.testuser.subject.structural;
 
-public class AbstractClassExtension extends SomeAbstractClass {
+public class AbstractClassExtension extends SomeAbstractClass implements SomeInterface {
 	@Override
 	void doNothing() {
 		// nothing
 	}
 
+	@SuppressWarnings("unused")
 	public void declaredMethod() {
 		// nothing
 	}
@@ -18,5 +19,10 @@ public class AbstractClassExtension extends SomeAbstractClass {
 	@SuppressWarnings("unused")
 	private void declaredMethod(String s) {
 		// nothing
+	}
+
+	@Override
+	public int doSomething(String someString) {
+		return 10;
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
@@ -4,6 +4,10 @@ public abstract class SomeAbstractClass {
 
 	public static int someInt = 2;
 
+	protected final String someProtectedAttribute = "hidden";
+
+	private final long somePrivateAttribute = 3L;
+
 	public SomeAbstractClass() {
 		// nothing
 	}
@@ -16,6 +20,10 @@ public abstract class SomeAbstractClass {
 	abstract void doNothing();
 
 	protected void nonAbstractProtected() {
+		// nothing
+	}
+
+	private void nonAbstractPrivate() {
 		// nothing
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
@@ -26,4 +26,8 @@ public abstract class SomeAbstractClass {
 	private void nonAbstractPrivate() {
 		// nothing
 	}
+
+	void nonAbstractPackagePrivate() {
+		// nothing
+	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
@@ -14,4 +14,8 @@ public abstract class SomeAbstractClass {
 	}
 
 	abstract void doNothing();
+
+	protected void nonAbstractProtected() {
+		// nothing
+	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeAbstractClass.java
@@ -6,6 +6,7 @@ public abstract class SomeAbstractClass {
 
 	protected final String someProtectedAttribute = "hidden";
 
+	@SuppressWarnings("unused")
 	private final long somePrivateAttribute = 3L;
 
 	public SomeAbstractClass() {
@@ -23,6 +24,7 @@ public abstract class SomeAbstractClass {
 		// nothing
 	}
 
+	@SuppressWarnings("unused")
 	private void nonAbstractPrivate() {
 		// nothing
 	}

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeClass.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/SomeClass.java
@@ -66,6 +66,7 @@ public class SomeClass implements SomeInterface {
 	}
 
 	private int superSecretMethod() {
-		return ThreadLocalRandom.current().nextInt(doSomethingOperations.size());
+		return ThreadLocalRandom.current()
+				.nextInt(doSomethingOperations == null ? SOME_CONSTANT : doSomethingOperations.size());
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/subpackage/SubpackageClass.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/subpackage/SubpackageClass.java
@@ -1,0 +1,7 @@
+package de.tum.in.test.integration.testuser.subject.structural.subpackage;
+
+import de.tum.in.test.integration.testuser.subject.structural.AbstractClassExtension;
+
+public class SubpackageClass extends AbstractClassExtension {
+	// intentionally empty, used to test for inherited methods and attributes
+}


### PR DESCRIPTION
# What?
This PR adds additional methods to the `ReflectionTestsUtils` to allow access to (package) private and protected attributes, constructors, and methods.

# Why?
Sometimes it might be useful to test for such non-accessible elements in classes. E.g.,
- check that utility classes explicitly define a private constructor that throws an `UnsupportedOperationException`,
- check that certain protected methods have been implemented in all subclasses of an abstract class,
- generally check that elements that have been described in the UML diagram for a task exist as specified.

In most cases this new functionality should not be needed but it might sometimes be helpful for beginners to ‘overspecify’ the model in the task UML and then provide feedback based on the exact implementation of a specific design pattern.


# Additional Context/Implementation Choices
- New methods with different names have been introduced instead of adding overloads for two reasons:
    - The access to private elements should be an explicit choice when writing a test. By default members that are designed to be non-accessible should remain inaccessible.
    - Adding overloads with an additional boolean flag is not really possible in some cases due to the vararg declarations.
- For the private methods I used `Object[]` arguments instead of `Object...` to make more obvious at the call-site that there exists an additional boolean flag that is not part of the constructor/method parameter list and to avoid accidentally passing more arguments than there should be.