### PR TITLE
Add public API to get non-public method

### DIFF
--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -301,8 +301,8 @@ public final class ReflectionTestUtils {
 	}
 
 	/**
-	 * Helper method that retrieves a public method with arguments of a given object by its
-	 * name.
+	 * Helper method that retrieves a public method with arguments of a given object
+	 * by its name.
 	 *
 	 * @param object         instance of the class that defines the method.
 	 * @param methodName     the name of the method.
@@ -327,8 +327,8 @@ public final class ReflectionTestUtils {
 	}
 
 	/**
-	 * Helper method that retrieves a non-public method with arguments of a given object by its
-	 * name.
+	 * Helper method that retrieves a non-public method with arguments of a given
+	 * object by its name.
 	 *
 	 * @param object         instance of the class that defines the method.
 	 * @param methodName     the name of the method.

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -1,14 +1,9 @@
 package de.tum.in.test.api.util;
 
-import static de.tum.in.test.api.localization.Messages.localized;
-import static de.tum.in.test.api.localization.Messages.localizedFailure;
+import static de.tum.in.test.api.localization.Messages.*;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.StringJoiner;
+import java.lang.reflect.*;
+import java.util.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -330,8 +325,8 @@ public final class ReflectionTestUtils {
 	 * Helper method that retrieves a non-public method with arguments of a given
 	 * object by its name.
 	 *
-	 * @param object         instance of the class that defines the method.
-	 * @param methodName     the name of the method.
+	 * @param object         Instance of the class that defines the method.
+	 * @param methodName     The name of the method.
 	 * @param parameterTypes The parameter types of this method.
 	 * @return The wanted method.
 	 */
@@ -494,8 +489,8 @@ public final class ReflectionTestUtils {
 	 * @param object The instance of the class that should invoke the method.
 	 * @param method The method that has to get invoked.
 	 * @param params Parameter instances of the method.
-	 * @throws Throwable the exception that was caught and which will be rethrown
 	 * @return The return value of the method.
+	 * @throws Throwable the exception that was caught and which will be rethrown
 	 */
 	public static Object invokeMethodRethrowing(Object object, Method method, Object... params) throws Throwable {
 		return invokeMethodRethrowingAccessible(object, method, false, params);
@@ -512,8 +507,8 @@ public final class ReflectionTestUtils {
 	 * @param object The instance of the class that should invoke the method.
 	 * @param method The method that has to get invoked.
 	 * @param params Parameter instances of the method.
-	 * @throws Throwable the exception that was caught and which will be rethrown
 	 * @return The return value of the method.
+	 * @throws Throwable the exception that was caught and which will be rethrown
 	 */
 	public static Object invokeNonPublicMethodRethrowing(Object object, Method method, Object... params)
 			throws Throwable {
@@ -530,8 +525,8 @@ public final class ReflectionTestUtils {
 	 *                    should be forced. Might fail with an
 	 *                    {@link IllegalAccessException} otherwise.
 	 * @param params      Parameter instances of the method.
-	 * @throws Throwable the exception that was caught and which will be rethrown
 	 * @return The return value of the method.
+	 * @throws Throwable the exception that was caught and which will be rethrown
 	 */
 	private static Object invokeMethodRethrowingAccessible(Object object, Method method, boolean forceAccess,
 			Object[] params) throws Throwable {

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -1,13 +1,18 @@
 package de.tum.in.test.api.util;
 
-import static de.tum.in.test.api.localization.Messages.*;
-
-import java.lang.reflect.*;
-import java.util.*;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.opentest4j.AssertionFailedError;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.StringJoiner;
+
+import static de.tum.in.test.api.localization.Messages.localized;
+import static de.tum.in.test.api.localization.Messages.localizedFailure;
 
 /**
  * This class serves as an API to Java Reflection to facilitate various
@@ -296,7 +301,7 @@ public final class ReflectionTestUtils {
 	}
 
 	/**
-	 * Helper method that retrieves a method with arguments of a given object by its
+	 * Helper method that retrieves a public method with arguments of a given object by its
 	 * name.
 	 *
 	 * @param object         instance of the class that defines the method.
@@ -310,7 +315,7 @@ public final class ReflectionTestUtils {
 	}
 
 	/**
-	 * Retrieve a method with arguments of a given class by its name.
+	 * Retrieve a public method with arguments of a given class by its name.
 	 *
 	 * @param declaringClass The class that declares this method.
 	 * @param methodName     The name of this method.
@@ -319,6 +324,32 @@ public final class ReflectionTestUtils {
 	 */
 	public static Method getMethod(Class<?> declaringClass, String methodName, Class<?>... parameterTypes) {
 		return getMethodAccessible(declaringClass, methodName, false, parameterTypes);
+	}
+
+	/**
+	 * Helper method that retrieves a non-public method with arguments of a given object by its
+	 * name.
+	 *
+	 * @param object         instance of the class that defines the method.
+	 * @param methodName     the name of the method.
+	 * @param parameterTypes The parameter types of this method.
+	 * @return The wanted method.
+	 */
+	public static Method getNonPublicMethod(Object object, String methodName, Class<?>... parameterTypes) {
+		requireNonNull(object, "reflection_test_utils.method_null_target", methodName); //$NON-NLS-1$
+		return getNonPublicMethod(object.getClass(), methodName, parameterTypes);
+	}
+
+	/**
+	 * Retrieve a non-public method with arguments of a given class by its name.
+	 *
+	 * @param declaringClass The class that declares this method.
+	 * @param methodName     The name of this method.
+	 * @param parameterTypes The parameter types of this method.
+	 * @return The wanted method.
+	 */
+	public static Method getNonPublicMethod(Class<?> declaringClass, String methodName, Class<?>... parameterTypes) {
+		return getMethodAccessible(declaringClass, methodName, true, parameterTypes);
 	}
 
 	/**

--- a/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
+++ b/src/main/java/de/tum/in/test/api/util/ReflectionTestUtils.java
@@ -1,8 +1,7 @@
 package de.tum.in.test.api.util;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-import org.opentest4j.AssertionFailedError;
+import static de.tum.in.test.api.localization.Messages.localized;
+import static de.tum.in.test.api.localization.Messages.localizedFailure;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -11,8 +10,9 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.StringJoiner;
 
-import static de.tum.in.test.api.localization.Messages.localized;
-import static de.tum.in.test.api.localization.Messages.localizedFailure;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * This class serves as an API to Java Reflection to facilitate various

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -1,16 +1,17 @@
 package de.tum.in.test.integration.testuser;
 
-import static de.tum.in.test.api.util.ReflectionTestUtils.*;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.lang.reflect.*;
-
-import org.junit.jupiter.api.Test;
-
-import de.tum.in.test.api.*;
+import de.tum.in.test.api.StrictTimeout;
+import de.tum.in.test.api.WhitelistPath;
 import de.tum.in.test.api.jupiter.Public;
 import de.tum.in.test.api.localization.UseLocale;
 import de.tum.in.test.integration.testuser.subject.structural.SomeClass;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static de.tum.in.test.api.util.ReflectionTestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Public
 @UseLocale("en")
@@ -54,6 +55,12 @@ public class ReflectionTestUtilsUser {
 	@Test
 	void testGetMethod_success() {
 		var method = getMethod(CLASS_INSTANCE, "getAnotherAttribute");
+		assertThat(method).isInstanceOf(Method.class);
+	}
+
+	@Test
+	void testGetNonPublicMethod_success() {
+		var method = getNonPublicMethod(CLASS_INSTANCE, "superSecretMethod");
 		assertThat(method).isInstanceOf(Method.class);
 	}
 

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -1,17 +1,18 @@
 package de.tum.in.test.integration.testuser;
 
+import static de.tum.in.test.api.util.ReflectionTestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
 import de.tum.in.test.api.StrictTimeout;
 import de.tum.in.test.api.WhitelistPath;
 import de.tum.in.test.api.jupiter.Public;
 import de.tum.in.test.api.localization.UseLocale;
 import de.tum.in.test.integration.testuser.subject.structural.SomeClass;
-import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
-import static de.tum.in.test.api.util.ReflectionTestUtils.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Public
 @UseLocale("en")

--- a/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ReflectionTestUtilsUser.java
@@ -3,13 +3,11 @@ package de.tum.in.test.integration.testuser;
 import static de.tum.in.test.api.util.ReflectionTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
+import java.lang.reflect.*;
 
 import org.junit.jupiter.api.Test;
 
-import de.tum.in.test.api.StrictTimeout;
-import de.tum.in.test.api.WhitelistPath;
+import de.tum.in.test.api.*;
 import de.tum.in.test.api.jupiter.Public;
 import de.tum.in.test.api.localization.UseLocale;
 import de.tum.in.test.integration.testuser.subject.structural.SomeClass;


### PR DESCRIPTION
While creating a new programming exercise recently, I stumbled across an older file containing custom ReflectionTestUtils methods to retrieve non-public methods and to invoke non-public methods.

Since all the functionality has already been implemented in Ares in #213, the only thing that was missing to entirely drop the custom ReflectionTestUtils class was a public API to retrieve but not invoke a non-public method.

That's the reason I created this PR.
 