### PR TITLE
Do not ignore cases for attribute names

### DIFF
--- a/src/main/java/de/tum/in/test/api/dynamic/DynamicClass.java
+++ b/src/main/java/de/tum/in/test/api/dynamic/DynamicClass.java
@@ -103,11 +103,11 @@ public class DynamicClass<T> implements Checkable {
 	}
 
 	public <R> DynamicField<R> field(DynamicClass<R> type, String... possibleNames) {
-		return new DynamicField<>(this, type, possibleNames);
+		return new DynamicField<>(this, type, false, possibleNames);
 	}
 
 	public <R> DynamicField<R> field(Class<R> type, String... possibleNames) {
-		return new DynamicField<>(this, type, possibleNames);
+		return new DynamicField<>(this, type, false, possibleNames);
 	}
 
 	public static <T> DynamicClass<T> toDynamic(Class<T> clazz) {

--- a/src/main/java/de/tum/in/test/api/dynamic/DynamicClass.java
+++ b/src/main/java/de/tum/in/test/api/dynamic/DynamicClass.java
@@ -103,11 +103,11 @@ public class DynamicClass<T> implements Checkable {
 	}
 
 	public <R> DynamicField<R> field(DynamicClass<R> type, String... possibleNames) {
-		return new DynamicField<>(this, type, true, possibleNames);
+		return new DynamicField<>(this, type, possibleNames);
 	}
 
 	public <R> DynamicField<R> field(Class<R> type, String... possibleNames) {
-		return new DynamicField<>(this, type, true, possibleNames);
+		return new DynamicField<>(this, type, possibleNames);
 	}
 
 	public static <T> DynamicClass<T> toDynamic(Class<T> clazz) {

--- a/src/main/java/de/tum/in/test/api/dynamic/DynamicField.java
+++ b/src/main/java/de/tum/in/test/api/dynamic/DynamicField.java
@@ -15,16 +15,22 @@ public class DynamicField<T> implements Checkable {
 	private final DynamicClass<?> owner;
 	private final List<String> name;
 	private final DynamicClass<T> type;
+	private final boolean ignoreCase;
+
 	private Field field;
 
-	public DynamicField(DynamicClass<?> dClass, Class<T> fType, String... possibleNames) {
-		this(dClass, DynamicClass.toDynamic(fType), possibleNames);
+	public DynamicField(DynamicClass<?> dClass, Class<T> fType, boolean ignoreCase, String... possibleNames) {
+		this(dClass, DynamicClass.toDynamic(fType), ignoreCase, possibleNames);
 	}
 
-	public DynamicField(DynamicClass<?> dClass, DynamicClass<T> fType, String... possibleNames) {
+	public DynamicField(DynamicClass<?> dClass, DynamicClass<T> fType, boolean ignoreCase, String... possibleNames) {
 		this.owner = Objects.requireNonNull(dClass);
-		this.name = List.of(possibleNames);
+		if (ignoreCase)
+			this.name = Stream.of(possibleNames).map(String::toLowerCase).collect(Collectors.toUnmodifiableList());
+		else
+			this.name = List.of(possibleNames);
 		this.type = Objects.requireNonNull(fType);
+		this.ignoreCase = ignoreCase;
 	}
 
 	public Field toField() {
@@ -73,7 +79,8 @@ public class DynamicField<T> implements Checkable {
 	}
 
 	private Optional<Field> findField(Class<?> c) {
-		return fieldsOf(c).stream().filter(f -> name.contains(f.getName())).findFirst();
+		return fieldsOf(c).stream().filter(f -> name.contains(ignoreCase ? f.getName().toLowerCase() : f.getName()))
+				.findFirst();
 	}
 
 	private List<Field> fieldsOf(Class<?> c) {

--- a/src/main/java/de/tum/in/test/api/dynamic/DynamicField.java
+++ b/src/main/java/de/tum/in/test/api/dynamic/DynamicField.java
@@ -15,21 +15,16 @@ public class DynamicField<T> implements Checkable {
 	private final DynamicClass<?> owner;
 	private final List<String> name;
 	private final DynamicClass<T> type;
-	private final boolean ignoreCase;
 	private Field field;
 
-	public DynamicField(DynamicClass<?> dClass, Class<T> fType, boolean ignoreCase, String... possibleNames) {
-		this(dClass, DynamicClass.toDynamic(fType), ignoreCase, possibleNames);
+	public DynamicField(DynamicClass<?> dClass, Class<T> fType, String... possibleNames) {
+		this(dClass, DynamicClass.toDynamic(fType), possibleNames);
 	}
 
-	public DynamicField(DynamicClass<?> dClass, DynamicClass<T> fType, boolean ignoreCase, String... possibleNames) {
+	public DynamicField(DynamicClass<?> dClass, DynamicClass<T> fType, String... possibleNames) {
 		this.owner = Objects.requireNonNull(dClass);
-		if (ignoreCase)
-			this.name = Stream.of(possibleNames).map(String::toLowerCase).collect(Collectors.toUnmodifiableList());
-		else
-			this.name = List.of(possibleNames);
+		this.name = List.of(possibleNames);
 		this.type = Objects.requireNonNull(fType);
-		this.ignoreCase = ignoreCase;
 	}
 
 	public Field toField() {
@@ -78,8 +73,7 @@ public class DynamicField<T> implements Checkable {
 	}
 
 	private Optional<Field> findField(Class<?> c) {
-		return fieldsOf(c).stream().filter(f -> name.contains(ignoreCase ? f.getName().toLowerCase() : f.getName()))
-				.findFirst();
+		return fieldsOf(c).stream().filter(f -> name.contains(f.getName())).findFirst();
 	}
 
 	private List<Field> fieldsOf(Class<?> c) {

--- a/src/main/java/de/tum/in/test/api/dynamic/DynamicField.java
+++ b/src/main/java/de/tum/in/test/api/dynamic/DynamicField.java
@@ -16,7 +16,6 @@ public class DynamicField<T> implements Checkable {
 	private final List<String> name;
 	private final DynamicClass<T> type;
 	private final boolean ignoreCase;
-
 	private Field field;
 
 	public DynamicField(DynamicClass<?> dClass, Class<T> fType, boolean ignoreCase, String... possibleNames) {

--- a/src/test/java/de/tum/in/test/integration/DynamicsTest.java
+++ b/src/test/java/de/tum/in/test/integration/DynamicsTest.java
@@ -49,9 +49,9 @@ class DynamicsTest {
 						+ "	org.opentest4j.AssertionFailedError: Klasse de.tum.in.test.integration.testuser.subject.structural.SomeClass ist public.\n" //
 						+ "	org.opentest4j.AssertionFailedError: Klasse de.tum.in.test.integration.testuser.subject.structural.SomeClass ist nicht final.\n" //
 						+ "	org.opentest4j.AssertionFailedError: Klasse de.tum.in.test.integration.testuser.subject.structural.SomeClass ist nicht statisch.\n" //
-						+ "	org.opentest4j.AssertionFailedError: Attribut de.tum.in.test.integration.testuser.subject.structural.SomeClass.[someattribute] ist nicht public.\n" //
-						+ "	org.opentest4j.AssertionFailedError: Attribut de.tum.in.test.integration.testuser.subject.structural.SomeClass.[some_constant] ist final.\n" //
-						+ "	org.opentest4j.AssertionFailedError: Attribut de.tum.in.test.integration.testuser.subject.structural.SomeClass.[some_constant] ist statisch." //
+						+ "	org.opentest4j.AssertionFailedError: Attribut de.tum.in.test.integration.testuser.subject.structural.SomeClass.[someAttribute] ist nicht public.\n" //
+						+ "	org.opentest4j.AssertionFailedError: Attribut de.tum.in.test.integration.testuser.subject.structural.SomeClass.[SOME_CONSTANT] ist final.\n" //
+						+ "	org.opentest4j.AssertionFailedError: Attribut de.tum.in.test.integration.testuser.subject.structural.SomeClass.[SOME_CONSTANT] ist statisch." //
 				, Option.MESSAGE_NORMALIZE_NEWLINE));
 	}
 
@@ -147,7 +147,7 @@ class DynamicsTest {
 	@TestTest
 	void test_field_wrongType() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(field_wrongType, AssertionFailedError.class,
-				"Attribut [some_constant] konnte nicht gefunden werden."));
+				"Attribut [SOME_CONSTANT] konnte nicht gefunden werden."));
 	}
 
 	@TestTest


### PR DESCRIPTION
Ares did ignore the cases of attributes so far, which lead to some problems when other tests relied on the exact case or the student had different attributes with the same name but different cases (i.e. id and static ID to count up all created ids).
This PR removes this behavior, so attributes are now case sensitive