### PR TITLE
Suggestion: Simplify AST-API and Unify Project Sources Search

### DIFF
--- a/src/main/java/de/tum/in/test/api/AresConfiguration.java
+++ b/src/main/java/de/tum/in/test/api/AresConfiguration.java
@@ -1,0 +1,64 @@
+package de.tum.in.test.api;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import de.tum.in.test.api.util.ProjectSourcesFinder;
+
+/**
+ * Utility class for global Ares configuration.
+ *
+ * @author Christian Femers
+ * @since 1.12.0
+ * @version 1.0.0
+ */
+@API(status = Status.MAINTAINED)
+public class AresConfiguration {
+
+	private AresConfiguration() {
+	}
+
+	/**
+	 * Returns the global Maven POM-file path used by Ares.
+	 * <p>
+	 * Defaults to the relative path <code>pom.xml</code>.
+	 *
+	 * @return the configured pom.xml file path as string
+	 */
+	public static String getPomXmlPath() {
+		return ProjectSourcesFinder.getPomXmlPath();
+	}
+
+	/**
+	 * Sets the global Maven POM-file path to the given file path string.
+	 * <p>
+	 * Set by default to the relative path <code>pom.xml</code>.
+	 *
+	 * @param path the path as string, may be both relative or absolute
+	 */
+	public static void setPomXmlPath(String path) {
+		ProjectSourcesFinder.setPomXmlPath(path);
+	}
+
+	/**
+	 * Returns the global Gradle build file path used by Ares.
+	 * <p>
+	 * Defaults to the relative path <code>build.gradle</code>.
+	 *
+	 * @return the configured gradle.build file path as string
+	 */
+	public static String getBuildGradlePath() {
+		return ProjectSourcesFinder.getBuildGradlePath();
+	}
+
+	/**
+	 * Sets the global Gradle build file path to the given file path string.
+	 * <p>
+	 * Set by default to the relative path <code>build.gradle</code>.
+	 *
+	 * @param path the path as string, may be both relative or absolute
+	 */
+	public static void setBuildGradlePath(String path) {
+		ProjectSourcesFinder.setBuildGradlePath(path);
+	}
+}

--- a/src/main/java/de/tum/in/test/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/in/test/api/ast/asserting/UnwantedNodesAssert.java
@@ -14,6 +14,7 @@ import org.assertj.core.api.AbstractAssert;
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.StaticJavaParser;
 
+import de.tum.in.test.api.AresConfiguration;
 import de.tum.in.test.api.ast.model.UnwantedNode;
 import de.tum.in.test.api.ast.type.*;
 import de.tum.in.test.api.util.ProjectSourcesFinder;
@@ -42,8 +43,12 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	}
 
 	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
+	 * Creates an unwanted node assertion object for all project source files.
+	 * <p>
+	 * The project source directory gets extracted from the build configuration, and
+	 * a <code>pom.xml</code> or <code>build.gradle</code> in the execution path is
+	 * the default build configuration location. The configuration here is the same
+	 * as the one in the structural tests and uses {@link AresConfiguration}.
 	 *
 	 * @return An unwanted node assertion object (for chaining)
 	 */

--- a/src/main/java/de/tum/in/test/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/in/test/api/ast/asserting/UnwantedNodesAssert.java
@@ -1,25 +1,29 @@
 package de.tum.in.test.api.ast.asserting;
 
 import static de.tum.in.test.api.localization.Messages.localized;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.fail;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
+import java.nio.file.*;
+import java.util.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.assertj.core.api.*;
+import org.assertj.core.api.AbstractAssert;
 
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.StaticJavaParser;
 
 import de.tum.in.test.api.ast.model.UnwantedNode;
 import de.tum.in.test.api.ast.type.*;
-import de.tum.in.test.api.structural.testutils.ClassNameScanner;
+import de.tum.in.test.api.util.ProjectSourcesFinder;
 
 /**
  * Checks whole Java files for unwanted nodes
+ *
+ * @author Markus Paulsen
+ * @since 1.12.0
+ * @version 1.0.0
  */
 @API(status = Status.MAINTAINED)
 public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Path> {
@@ -30,160 +34,58 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	private final LanguageLevel level;
 
 	private UnwantedNodesAssert(Path path, LanguageLevel level) {
-		super(path, UnwantedNodesAssert.class);
+		super(requireNonNull(path), UnwantedNodesAssert.class);
 		this.level = level;
-	}
-
-	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @param delocatedBuildFile Path to a delocated build file (or '' if the build
-	 *                           file is not delocated), which describes part of the
-	 *                           relative path
-	 * @param relativePackage    The part of the relative path, which is described
-	 *                           by the package
-	 * @param relativePath       The part of the relative path, which is described
-	 *                           by the file path
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatProjectSources(String delocatedBuildFile, String relativePackage,
-			String relativePath) {
-		UnwantedNodesAssert empty = (new UnwantedNodesAssert(null, null));
-		if (delocatedBuildFile == null) {
-			empty.failWithMessage("The 'delocatedBuildFile' must not be null.");
+		if (!Files.isDirectory(path)) {
+			fail("The source directory %s does not exist", path); //$NON-NLS-1$
 		}
-		if (relativePackage == null) {
-			empty.failWithMessage("The 'relativePackage' must not be null.");
-		}
-		if (relativePath == null) {
-			empty.failWithMessage("The 'relativePath' must not be null.");
-		}
-		assert delocatedBuildFile != null;
-		if (!delocatedBuildFile.equals("")) {
-			Path delocatedBuildFilePath = Path.of(delocatedBuildFile);
-			if (!Files.exists(delocatedBuildFilePath)) {
-				empty.failWithMessage("The 'delocatedBuildFile' " + delocatedBuildFile + " does not exist.");
-			}
-			if (Files.isDirectory(delocatedBuildFilePath)) {
-				empty.failWithMessage("The 'delocatedBuildFile' " + delocatedBuildFile + " must not be a directory.");
-			}
-			if (!delocatedBuildFilePath.endsWith("pom.xml") && !delocatedBuildFilePath.endsWith("build.gradle")) {
-				empty.failWithMessage("The 'delocatedBuildFile' must be a 'pom.xml' or a 'build.gradle' file.");
-			}
-		}
-		Path fullPath = getFullPath(delocatedBuildFile, relativePackage, relativePath);
-		if (!Files.exists(fullPath)) {
-			empty.failWithMessage("The path " + fullPath + " (resulting from the relativePackage " + relativePackage
-					+ ", the relativePath " + relativePath + " and the delocatedBuildFile " + delocatedBuildFile
-					+ ") does not exist.");
-		}
-
-		return new UnwantedNodesAssert(fullPath, null);
 	}
 
 	/**
 	 * Creates an unwanted node assertion object for all files below the relative
 	 * path
-	 * 
-	 * @param relativePackage The part of the relative path, which is described by
-	 *                        the package
-	 * @param relativePath    The part of the relative path, which is described by
-	 *                        the file path
+	 *
 	 * @return An unwanted node assertion object (for chaining)
 	 */
-	public static UnwantedNodesAssert assertThatProjectSources(String relativePackage, String relativePath) {
-		return UnwantedNodesAssert.assertThatProjectSources("", relativePackage, relativePath);
+	public static UnwantedNodesAssert assertThatProjectSources() {
+		var path = ProjectSourcesFinder.findProjectSourcesPath().orElseThrow(() -> new AssertionError("" //$NON-NLS-1$
+				+ "Could not find project sources folder." //$NON-NLS-1$
+				+ " Make sure the build file is configured correctly." //$NON-NLS-1$
+				+ " If it is not located in the execution folder directly," //$NON-NLS-1$
+				+ " set the location using AresConfiguration methods.")); //$NON-NLS-1$
+		return new UnwantedNodesAssert(path, null);
 	}
 
 	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @param delocatedBuildFile Path to a delocated build file (or '' if the build
-	 *                           file is not delocated), which describes part of the
-	 *                           relative path
-	 * @param relativePackage    The part of the relative path, which is described
-	 *                           by the package
+	 * Creates an unwanted node assertion object for all source files at and below
+	 * the given directory path.
+	 *
+	 * @param directory Path to a directory under which all files are considered
 	 * @return An unwanted node assertion object (for chaining)
 	 */
-	public static UnwantedNodesAssert assertThatAllProjectSourcesAtPackage(String delocatedBuildFile,
-			String relativePackage) {
-		return UnwantedNodesAssert.assertThatProjectSources(delocatedBuildFile, relativePackage, "");
+	public static UnwantedNodesAssert assertThatSourcesIn(Path directory) {
+		Objects.requireNonNull(directory, "The given source path must not be null."); //$NON-NLS-1$
+		return new UnwantedNodesAssert(directory, null);
 	}
 
 	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @param relativePackage The part of the relative path, which is described by
-	 *                        the package
+	 * Creates an unwanted node assertion object for all source files in the given
+	 * package, including all of its sub-packages.
+	 *
+	 * @param packageName Java package name in the form of, e.g.,
+	 *                    <code>de.tum.in.test.api</code>, which is resolved
+	 *                    relative to the path of this UnwantedNodesAssert.
 	 * @return An unwanted node assertion object (for chaining)
+	 * @implNote The package is split at "." with the resulting segments being
+	 *           interpreted as directory structure. So
+	 *           <code>assertThatSourcesIn(Path.of("src/main/java")).withinPackage("net.example.test")</code>
+	 *           will yield an assert for all source files located at and below the
+	 *           relative path <code>src/main/java/net/example/test</code>
 	 */
-	public static UnwantedNodesAssert assertThatAllProjectSourcesAtPackage(String relativePackage) {
-		return UnwantedNodesAssert.assertThatProjectSources("", relativePackage, "");
-	}
-
-	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @param delocatedBuildFile Path to a delocated build file (or '' if the build
-	 *                           file is not delocated), which describes part of the
-	 *                           relative path
-	 * @param relativePath       The part of the relative path, which is described
-	 *                           by the file path
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatAllProjectSourcesAtPath(String delocatedBuildFile,
-			String relativePath) {
-		return UnwantedNodesAssert.assertThatProjectSources(delocatedBuildFile, "", relativePath);
-	}
-
-	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @param relativePath The part of the relative path, which is described by the
-	 *                     file path
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatAllProjectSourcesAtPath(String relativePath) {
-		return UnwantedNodesAssert.assertThatProjectSources("", "", relativePath);
-	}
-
-	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @param delocatedBuildFile Path to a delocated build file (or '' if the build
-	 *                           file is not delocated), which describes part of the
-	 *                           relative path
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatAllProjectSources(String delocatedBuildFile) {
-		return UnwantedNodesAssert.assertThatProjectSources(delocatedBuildFile, "", "");
-	}
-
-	/**
-	 * Creates an unwanted node assertion object for all files below the relative
-	 * path
-	 * 
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThatAllProjectSources() {
-		return UnwantedNodesAssert.assertThatProjectSources("", "", "");
-	}
-
-	/**
-	 * Creates an unwanted node assertion object for all files below the absolute
-	 * path
-	 * 
-	 * @param absolutePath Path under which all files are considered
-	 * @return An unwanted node assertion object (for chaining)
-	 */
-	public static UnwantedNodesAssert assertThat(String absolutePath) {
-		return new UnwantedNodesAssert(Path.of(absolutePath), null);
+	public UnwantedNodesAssert withinPackage(String packageName) {
+		Objects.requireNonNull(packageName, "The package name must not be null."); //$NON-NLS-1$
+		var newPath = actual.resolve(Path.of("", packageName.split("\\."))); //$NON-NLS-1$ //$NON-NLS-2$
+		return new UnwantedNodesAssert(newPath, level);
 	}
 
 	/**
@@ -208,38 +110,14 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	 * @see LoopType
 	 */
 	public UnwantedNodesAssert hasNo(Type type) {
-		isNotNull();
 		if (level == null) {
-			failWithMessage("The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel).");
+			failWithMessage("The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel)."); //$NON-NLS-1$
 		}
 		StaticJavaParser.getParserConfiguration().setLanguageLevel(level);
 		Optional<String> errorMessage = UnwantedNode.getMessageForUnwantedNodesForAllFilesBelow(actual,
 				type.getNodeNameNodeMap());
 		errorMessage.ifPresent(unwantedNodeMessageForAllJavaFiles -> failWithMessage(
-				localized("ast.method.has_no") + System.lineSeparator() + unwantedNodeMessageForAllJavaFiles));
+				localized("ast.method.has_no") + System.lineSeparator() + unwantedNodeMessageForAllJavaFiles)); //$NON-NLS-1$
 		return this;
-	}
-
-	private static Path getFullPath(String delocatedBuildFile, String relativePackage, String relativePath) {
-		String oldPomXmlPath = ClassNameScanner.getPomXmlPath();
-		String oldBuildGradlePath = ClassNameScanner.getBuildGradlePath();
-		if (!delocatedBuildFile.equals("")) {
-			if (delocatedBuildFile.endsWith("pom.xml")) {
-				ClassNameScanner.setPomXmlPath(delocatedBuildFile);
-				ClassNameScanner.setBuildGradlePath(null);
-			} else {
-				ClassNameScanner.setPomXmlPath(null);
-				ClassNameScanner.setBuildGradlePath(delocatedBuildFile);
-			}
-		}
-		Path fullPath = (new ClassNameScanner(relativePath, relativePackage)).getAssignmentFolderName()
-				.map(assignmentFolderName -> Path.of(".", assignmentFolderName,
-						String.join(File.separator, relativePackage.split("\\.")), relativePath))
-				.orElseThrow();
-		if (!delocatedBuildFile.equals("")) {
-			ClassNameScanner.setBuildGradlePath(oldPomXmlPath);
-			ClassNameScanner.setPomXmlPath(oldBuildGradlePath);
-		}
-		return fullPath;
 	}
 }

--- a/src/main/java/de/tum/in/test/api/ast/type/ClassType.java
+++ b/src/main/java/de/tum/in/test/api/ast/type/ClassType.java
@@ -8,9 +8,18 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt;
-import com.github.javaparser.ast.stmt.LocalRecordDeclarationStmt;
+import com.github.javaparser.ast.stmt.*;
 
+import de.tum.in.test.api.ast.asserting.UnwantedNodesAssert;
+
+/**
+ * Enumerates class Java statements which can be checked using
+ * {@link UnwantedNodesAssert}.
+ *
+ * @author Markus Paulsen
+ * @since 1.12.0
+ * @version 1.0.0
+ */
 @API(status = Status.MAINTAINED)
 public enum ClassType implements Type {
 	/**

--- a/src/main/java/de/tum/in/test/api/ast/type/ConditionalType.java
+++ b/src/main/java/de/tum/in/test/api/ast/type/ConditionalType.java
@@ -8,10 +8,19 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.expr.ConditionalExpr;
-import com.github.javaparser.ast.expr.SwitchExpr;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 
+import de.tum.in.test.api.ast.asserting.UnwantedNodesAssert;
+
+/**
+ * Enumerates all conditional Java statements and expressions which can be
+ * checked using {@link UnwantedNodesAssert}.
+ *
+ * @author Markus Paulsen
+ * @since 1.12.0
+ * @version 1.0.0
+ */
 @API(status = Status.MAINTAINED)
 public enum ConditionalType implements Type {
 	/**

--- a/src/main/java/de/tum/in/test/api/ast/type/ExceptionHandlingType.java
+++ b/src/main/java/de/tum/in/test/api/ast/type/ExceptionHandlingType.java
@@ -10,6 +10,16 @@ import org.apiguardian.api.API.Status;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.stmt.*;
 
+import de.tum.in.test.api.ast.asserting.UnwantedNodesAssert;
+
+/**
+ * Enumerates exception handling Java constructs which can be checked using
+ * {@link UnwantedNodesAssert}.
+ *
+ * @author Markus Paulsen
+ * @since 1.12.0
+ * @version 1.0.0
+ */
 @API(status = Status.MAINTAINED)
 public enum ExceptionHandlingType implements Type {
 	/**

--- a/src/main/java/de/tum/in/test/api/ast/type/LoopType.java
+++ b/src/main/java/de/tum/in/test/api/ast/type/LoopType.java
@@ -10,6 +10,16 @@ import org.apiguardian.api.API.Status;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.stmt.*;
 
+import de.tum.in.test.api.ast.asserting.UnwantedNodesAssert;
+
+/**
+ * Enumerates all Java loop types which can be checked using
+ * {@link UnwantedNodesAssert}.
+ *
+ * @author Markus Paulsen
+ * @since 1.12.0
+ * @version 1.0.0
+ */
 @API(status = Status.MAINTAINED)
 public enum LoopType implements Type {
 	/**

--- a/src/main/java/de/tum/in/test/api/ast/type/Type.java
+++ b/src/main/java/de/tum/in/test/api/ast/type/Type.java
@@ -7,6 +7,17 @@ import org.apiguardian.api.API.Status;
 
 import com.github.javaparser.ast.Node;
 
+import de.tum.in.test.api.ast.asserting.UnwantedNodesAssert;
+
+/**
+ * Describes a type of syntactic construct in Java in the bread sense (e.g., all
+ * loop statements together can also be regarded as "the loop type"). Can be
+ * checked using {@link UnwantedNodesAssert}.
+ *
+ * @author Markus Paulsen
+ * @since 1.12.0
+ * @version 1.0.0
+ */
 @API(status = Status.MAINTAINED)
 public interface Type {
 

--- a/src/main/java/de/tum/in/test/api/structural/testutils/ClassNameScanner.java
+++ b/src/main/java/de/tum/in/test/api/structural/testutils/ClassNameScanner.java
@@ -3,23 +3,19 @@ package de.tum.in.test.api.structural.testutils;
 import static de.tum.in.test.api.localization.Messages.localized;
 import static de.tum.in.test.api.structural.testutils.ScanResultType.*;
 
-import java.io.*;
-import java.nio.file.*;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.*;
-
-import javax.xml.XMLConstants;
-import javax.xml.parsers.*;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.*;
-import org.w3c.dom.*;
-import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
 
 import info.debatty.java.stringsimilarity.*;
+
+import de.tum.in.test.api.AresConfiguration;
+import de.tum.in.test.api.util.ProjectSourcesFinder;
 
 /**
  * This class scans the submission project if the current expected class is
@@ -83,18 +79,6 @@ public class ClassNameScanner {
 	private final Map<String, List<String>> observedClasses = new HashMap<>();
 	private final ScanResult scanResult;
 
-	private static String pomXmlPath = "pom.xml"; //$NON-NLS-1$
-	private static String buildGradlePath = "build.gradle"; //$NON-NLS-1$
-
-	private Optional<String> assignmentFolderName = Optional.empty();
-
-	/**
-	 * Pattern for matching the assignment folder name for the build.gradle file of
-	 * a Gradle project
-	 */
-	private static final Pattern gradleSourceDirPattern = Pattern
-			.compile("def\\s+assignmentSrcDir\\s*=\\s*\"(?<dir>.+)\""); //$NON-NLS-1$
-
 	public ClassNameScanner(String expectedClassName, String expectedPackageName) {
 		this.expectedClassName = expectedClassName;
 		this.expectedPackageName = expectedPackageName;
@@ -104,10 +88,6 @@ public class ClassNameScanner {
 
 	public ScanResult getScanResult() {
 		return scanResult;
-	}
-
-	public Optional<String> getAssignmentFolderName() {
-		return assignmentFolderName;
 	}
 
 	/**
@@ -226,89 +206,12 @@ public class ClassNameScanner {
 	 * defined in the project build file (pom.xml or build.gradle) of the project.
 	 */
 	private void findObservedClassesInProject() {
-		if (isMavenProject()) {
-			assignmentFolderName = Optional.ofNullable(getAssignmentFolderNameForMavenProject());
-		} else if (isGradleProject()) {
-			assignmentFolderName = Optional.ofNullable(getAssignmentFolderNameForGradleProject());
-		} else {
-			LOG.error("Could not find any build file. Contact your instructor."); //$NON-NLS-1$
-			assignmentFolderName = Optional.empty();
-			return;
-		}
-
+		var assignmentFolderName = ProjectSourcesFinder.findProjectSourcesPath();
 		if (assignmentFolderName.isPresent()) {
-			walkProjectFileStructure(assignmentFolderName.get(), new File(assignmentFolderName.get()), observedClasses);
+			walkProjectFileStructure(assignmentFolderName.get(), assignmentFolderName.get().toFile(), observedClasses);
 		} else {
 			LOG.error("Could not retrieve source directory from project file. Contact your instructor."); //$NON-NLS-1$ ´
 		}
-	}
-
-	private static boolean isMavenProject() {
-		if (pomXmlPath == null)
-			return false;
-		File projectFile = new File(pomXmlPath);
-		return projectFile.exists() && !projectFile.isDirectory();
-	}
-
-	private static boolean isGradleProject() {
-		if (buildGradlePath == null)
-			return false;
-		File projectFile = new File(buildGradlePath);
-		return projectFile.exists() && !projectFile.isDirectory();
-	}
-
-	/**
-	 * Retrieves the assignment folder name for a maven project from the pom.xml
-	 *
-	 * @return the folder name of the maven project, relative to project root
-	 */
-	private static String getAssignmentFolderNameForMavenProject() {
-		try {
-			var pomFile = new File(pomXmlPath);
-			var documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			// make sure to avoid loading external files which would not be compliant
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ""); //$NON-NLS-1$
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); //$NON-NLS-1$
-			var documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			var pomXmlDocument = documentBuilder.parse(pomFile);
-
-			NodeList buildNodes = pomXmlDocument.getElementsByTagName("build"); //$NON-NLS-1$
-			for (var i = 0; i < buildNodes.getLength(); i++) {
-				var buildNode = buildNodes.item(i);
-				if (buildNode.getNodeType() == Node.ELEMENT_NODE) {
-					var buildNodeElement = (Element) buildNode;
-					var sourceDirectoryPropertyValue = buildNodeElement.getElementsByTagName("sourceDirectory").item(0) //$NON-NLS-1$
-							.getTextContent();
-					return sourceDirectoryPropertyValue.substring(sourceDirectoryPropertyValue.indexOf("}") + 2); //$NON-NLS-1$
-				}
-			}
-		} catch (ParserConfigurationException | SAXException | IOException | NullPointerException e) {
-			LOG.error("Could not retrieve the source directory from the pom.xml file. Contact your instructor.", e); //$NON-NLS-1$
-		}
-		return null;
-	}
-
-	/**
-	 * Retrieves the assignment folder name for a gradle project from the
-	 * build.gradle
-	 *
-	 * @return the folder name of the gradle project, relative to project root
-	 */
-	private static String getAssignmentFolderNameForGradleProject() {
-		try {
-			var path = Path.of(buildGradlePath);
-			String fileContent = Files.readString(path);
-
-			var matcher = gradleSourceDirPattern.matcher(fileContent);
-			if (matcher.find()) {
-				return matcher.group("dir"); //$NON-NLS-1$
-			}
-			return null;
-		} catch (IOException | NullPointerException e) {
-			LOG.error("Could not retrieve the source directory from the build.gradle file. Contact your instructor.", //$NON-NLS-1$
-					e);
-		}
-		return null;
 	}
 
 	/**
@@ -316,14 +219,13 @@ public class ClassNameScanner {
 	 * the assignment folder and adds each type it finds e.g. filenames ending with
 	 * <code>.java</code> and <code>.kt</code> to the passed JSON object.
 	 *
-	 * @param assignmentFolderName The root folder where the method starts walking
-	 *                             the project structure.
-	 * @param node                 The current node the method is visiting.
-	 * @param foundClasses         The JSON object where the type names and packages
-	 *                             get appended.
+	 * @param assignmentFolder The root folder where the method starts walking the
+	 *                         project structure.
+	 * @param node             The current node the method is visiting.
+	 * @param foundClasses     The JSON object where the type names and packages get
+	 *                         appended.
 	 */
-	private void walkProjectFileStructure(String assignmentFolderName, File node,
-			Map<String, List<String>> foundClasses) {
+	private void walkProjectFileStructure(Path assignmentFolder, File node, Map<String, List<String>> foundClasses) {
 		// Example:
 		// * assignmentFolderName: assignment/src
 		// * fileName: assignment/src/de/tum/in/ase/eist/BubbleSort.java
@@ -334,7 +236,7 @@ public class ClassNameScanner {
 			var fileNameComponents = fileName.split("\\."); //$NON-NLS-1$
 			var className = fileNameComponents[fileNameComponents.length - 2];
 
-			Path packagePath = Path.of(assignmentFolderName).relativize(Path.of(node.getPath()).getParent());
+			Path packagePath = assignmentFolder.relativize(Path.of(node.getPath()).getParent());
 			var packageName = StreamSupport.stream(packagePath.spliterator(), false).map(Object::toString)
 					.collect(Collectors.joining(".")); //$NON-NLS-1$
 
@@ -348,24 +250,64 @@ public class ClassNameScanner {
 			String[] subNodes = node.list();
 			if (subNodes != null && subNodes.length > 0)
 				for (String currentSubNode : subNodes)
-					walkProjectFileStructure(assignmentFolderName, new File(node, currentSubNode), foundClasses);
+					walkProjectFileStructure(assignmentFolder, new File(node, currentSubNode), foundClasses);
 		}
 	}
 
+	/**
+	 * Returns the global Maven POM-file path used by Ares.
+	 * <p>
+	 * Defaults to the relative path <code>pom.xml</code>.
+	 *
+	 * @return the configured pom.xml file path as string
+	 * @deprecated Moved to a more general package. Please use
+	 *             {@link AresConfiguration#getPomXmlPath()} instead.
+	 */
+	@Deprecated(since = "1.12.0")
 	public static String getPomXmlPath() {
-		return pomXmlPath;
+		return AresConfiguration.getPomXmlPath();
 	}
 
+	/**
+	 * Sets the global Maven POM-file path to the given file path string.
+	 * <p>
+	 * Set by default to the relative path <code>pom.xml</code>.
+	 *
+	 * @param path the path as string, may be both relative or absolute
+	 * @deprecated Moved to a more general package. Please use
+	 *             {@link AresConfiguration#setPomXmlPath(String)} instead.
+	 */
+	@Deprecated(since = "1.12.0")
 	public static void setPomXmlPath(String path) {
-		pomXmlPath = path;
+		AresConfiguration.setPomXmlPath(path);
 	}
 
+	/**
+	 * Returns the global Gradle build file path used by Ares.
+	 * <p>
+	 * Defaults to the relative path <code>build.gradle</code>.
+	 *
+	 * @return the configured gradle.build file path as string
+	 * @deprecated Moved to a more general package. Please use
+	 *             {@link AresConfiguration#getBuildGradlePath()} instead.
+	 */
+	@Deprecated(since = "1.12.0")
 	public static String getBuildGradlePath() {
-		return buildGradlePath;
+		return AresConfiguration.getBuildGradlePath();
 	}
 
+	/**
+	 * Sets the global Gradle build file path to the given file path string.
+	 * <p>
+	 * Set by default to the relative path <code>build.gradle</code>.
+	 *
+	 * @param path the path as string, may be both relative or absolute
+	 * @deprecated Moved to a more general package. Please use
+	 *             {@link AresConfiguration#setBuildGradlePath(String)} instead.
+	 */
+	@Deprecated(since = "1.12.0")
 	public static void setBuildGradlePath(String path) {
-		buildGradlePath = path;
+		AresConfiguration.setBuildGradlePath(path);
 	}
 
 	static boolean isMisspelledWithHighProbability(String a, String b) {

--- a/src/main/java/de/tum/in/test/api/util/ProjectSourcesFinder.java
+++ b/src/main/java/de/tum/in/test/api/util/ProjectSourcesFinder.java
@@ -1,0 +1,141 @@
+package de.tum.in.test.api.util;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.*;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.slf4j.*;
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
+
+import de.tum.in.test.api.AresConfiguration;
+
+@API(status = Status.INTERNAL)
+public class ProjectSourcesFinder {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ProjectSourcesFinder.class);
+
+	/**
+	 * Pattern for matching the assignment folder name for the build.gradle file of
+	 * a Gradle project
+	 */
+	private static final Pattern GRADLE_SOURCE_DIR_PATTERN = Pattern
+			.compile("def\\s+assignmentSrcDir\\s*=\\s*\"(?<dir>.+)\""); //$NON-NLS-1$
+
+	private static String pomXmlPath = "pom.xml"; //$NON-NLS-1$
+	private static String buildGradlePath = "build.gradle"; //$NON-NLS-1$
+
+	/**
+	 * Returns the project sources path depending on the Ares and project
+	 * configuration.
+	 * <p>
+	 * This methods extracts the source path from the project build file, depending
+	 * on whether a pom.xml or build.gradle file was found this method looks. The
+	 * location of the project build file can be configured using
+	 * {@link AresConfiguration}.
+	 *
+	 * @return An empty optional if no project build file was found or if the build
+	 *         file did not contain the sources path in the format required by Ares.
+	 */
+	public static Optional<Path> findProjectSourcesPath() {
+		String assignmentFolderName = null;
+		if (isMavenProject()) {
+			assignmentFolderName = getAssignmentFolderNameForMavenProject();
+		} else if (isGradleProject()) {
+			assignmentFolderName = getAssignmentFolderNameForGradleProject();
+		} else {
+			LOG.error("Could not find any build file. Contact your instructor."); //$NON-NLS-1$
+		}
+		return Optional.ofNullable(assignmentFolderName).map(Path::of);
+	}
+
+	public static boolean isMavenProject() {
+		if (pomXmlPath == null)
+			return false;
+		File projectFile = new File(pomXmlPath);
+		return projectFile.exists() && !projectFile.isDirectory();
+	}
+
+	public static boolean isGradleProject() {
+		if (buildGradlePath == null)
+			return false;
+		File projectFile = new File(buildGradlePath);
+		return projectFile.exists() && !projectFile.isDirectory();
+	}
+
+	/**
+	 * Retrieves the assignment folder name for a maven project from the pom.xml
+	 *
+	 * @return the folder name of the maven project, relative to project root
+	 */
+	private static String getAssignmentFolderNameForMavenProject() {
+		try {
+			var pomFile = new File(pomXmlPath);
+			var documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			// make sure to avoid loading external files which would not be compliant
+			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ""); //$NON-NLS-1$
+			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); //$NON-NLS-1$
+			var documentBuilder = documentBuilderFactory.newDocumentBuilder();
+			var pomXmlDocument = documentBuilder.parse(pomFile);
+
+			NodeList buildNodes = pomXmlDocument.getElementsByTagName("build"); //$NON-NLS-1$
+			for (var i = 0; i < buildNodes.getLength(); i++) {
+				var buildNode = buildNodes.item(i);
+				if (buildNode.getNodeType() == Node.ELEMENT_NODE) {
+					var buildNodeElement = (Element) buildNode;
+					var sourceDirectoryPropertyValue = buildNodeElement.getElementsByTagName("sourceDirectory").item(0) //$NON-NLS-1$
+							.getTextContent();
+					return sourceDirectoryPropertyValue.substring(sourceDirectoryPropertyValue.indexOf("}") + 2); //$NON-NLS-1$
+				}
+			}
+		} catch (ParserConfigurationException | SAXException | IOException | NullPointerException e) {
+			LOG.error("Could not retrieve the source directory from the pom.xml file. Contact your instructor.", e); //$NON-NLS-1$
+		}
+		return null;
+	}
+
+	/**
+	 * Retrieves the assignment folder name for a gradle project from the
+	 * build.gradle
+	 *
+	 * @return the folder name of the gradle project, relative to project root
+	 */
+	private static String getAssignmentFolderNameForGradleProject() {
+		try {
+			var path = Path.of(buildGradlePath);
+			String fileContent = Files.readString(path);
+
+			var matcher = GRADLE_SOURCE_DIR_PATTERN.matcher(fileContent);
+			if (matcher.find()) {
+				return matcher.group("dir"); //$NON-NLS-1$
+			}
+			return null;
+		} catch (IOException | NullPointerException e) {
+			LOG.error("Could not retrieve the source directory from the build.gradle file. Contact your instructor.", //$NON-NLS-1$
+					e);
+		}
+		return null;
+	}
+
+	public static String getPomXmlPath() {
+		return pomXmlPath;
+	}
+
+	public static void setPomXmlPath(String path) {
+		pomXmlPath = path;
+	}
+
+	public static String getBuildGradlePath() {
+		return buildGradlePath;
+	}
+
+	public static void setBuildGradlePath(String path) {
+		buildGradlePath = path;
+	}
+}

--- a/src/test/java/de/tum/in/test/integration/AstAssertionTest.java
+++ b/src/test/java/de/tum/in/test/integration/AstAssertionTest.java
@@ -1,18 +1,14 @@
 package de.tum.in.test.integration;
 
-import static de.tum.in.test.testutilities.CustomConditions.finishedSuccessfully;
-import static de.tum.in.test.testutilities.CustomConditions.testFailedWith;
+import static de.tum.in.test.testutilities.CustomConditions.*;
 
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.*;
 import org.junit.platform.testkit.engine.Events;
 
 import de.tum.in.test.integration.testuser.AstAssertionUser;
-import de.tum.in.test.testutilities.TestTest;
-import de.tum.in.test.testutilities.UserBased;
-import de.tum.in.test.testutilities.UserTestResults;
+import de.tum.in.test.testutilities.*;
 
 @UserBased(AstAssertionUser.class)
 public class AstAssertionTest {
@@ -39,7 +35,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoForLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
@@ -63,7 +59,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoForEachLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - For-Each-Statement was found:"
@@ -88,7 +84,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoWhileLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - While-Statement was found:"
@@ -113,7 +109,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoDoWhileLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - Do-While-Statement was found:"
@@ -138,7 +134,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoAnyForLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
@@ -165,7 +161,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoAnyWhileLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - While-Statement was found:"
@@ -192,7 +188,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoAnyLoop_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "loops", "yes",
 											"ClassWithAnyKindsOfLoops.java")
 									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
@@ -222,7 +218,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoIfConditional_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "conditionals", "yes",
 											"ClassWithAnyKindsOfConditionals.java")
 									+ ":" + System.lineSeparator() + "  - If-Statement was found:"
@@ -248,7 +244,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1, testFailedWith(testHasBelowNoIfConditional_Fail,
 					AssertionError.class,
 					"Unwanted statement found:" + System.lineSeparator() + " - In "
-							+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration", "testuser",
+							+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration", "testuser",
 									"subject", "structural", "astTestFiles", "conditionals", "yes",
 									"ClassWithAnyKindsOfConditionals.java")
 							+ ":" + System.lineSeparator() + "  - If-Expression was found:" + System.lineSeparator()
@@ -273,7 +269,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoSwitchConditional_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "conditionals", "yes",
 											"ClassWithAnyKindsOfConditionals.java")
 									+ ":" + System.lineSeparator() + "  - Switch-Statement was found:"
@@ -298,8 +294,8 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1, testFailedWith(testHasBelowNoSwitchConditional_Fail,
 					AssertionError.class,
 					"Unwanted statement found:" + System.lineSeparator() + " - In "
-							+ Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-									"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "yes",
+							+ Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
+									"javaClassesWithUnsupportedFeatures", "conditionals", "yes",
 									"ClassWithAnyKindsOfUnsupportedConditionals.java")
 							+ ":" + System.lineSeparator() + "  - Switch-Expression was found:" + System.lineSeparator()
 							+ "   - Between line 38 (column 28) and line 43 (column 9)"));
@@ -321,7 +317,7 @@ public class AstAssertionTest {
 			String testHasBelowNoAnyClass_Fail = "testHasBelowNoAnyIf_Fail";
 			tests.assertThatEvents().haveExactly(1, testFailedWith(testHasBelowNoAnyClass_Fail, AssertionError.class,
 					"Unwanted statement found:" + System.lineSeparator() + " - In "
-							+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration", "testuser",
+							+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration", "testuser",
 									"subject", "structural", "astTestFiles", "conditionals", "yes",
 									"ClassWithAnyKindsOfConditionals.java")
 							+ ":" + System.lineSeparator() + "  - If-Statement was found:" + System.lineSeparator()
@@ -348,8 +344,8 @@ public class AstAssertionTest {
 			String testHasBelowNoAnyClass_Fail = "testHasBelowNoAnySwitch_Fail";
 			tests.assertThatEvents().haveExactly(1, testFailedWith(testHasBelowNoAnyClass_Fail, AssertionError.class,
 					"Unwanted statement found:" + System.lineSeparator() + " - In "
-							+ Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-									"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "yes",
+							+ Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
+									"javaClassesWithUnsupportedFeatures", "conditionals", "yes",
 									"ClassWithAnyKindsOfUnsupportedConditionals.java")
 							+ ":" + System.lineSeparator() + "  - Switch-Statement was found:" + System.lineSeparator()
 							+ "   - Between line 23 (column 9) and line 33 (column 9)" + System.lineSeparator()
@@ -374,8 +370,8 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1, testFailedWith(testHasBelowNoAnyConditional_Fail,
 					AssertionError.class,
 					"Unwanted statement found:" + System.lineSeparator() + " - In "
-							+ Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-									"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "yes",
+							+ Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
+									"javaClassesWithUnsupportedFeatures", "conditionals", "yes",
 									"ClassWithAnyKindsOfUnsupportedConditionals.java")
 							+ ":" + System.lineSeparator() + "  - If-Statement was found:" + System.lineSeparator()
 							+ "   - Between line 7 (column 9) and line 13 (column 9)" + System.lineSeparator()
@@ -408,7 +404,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoClass_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "classes", "yes",
 											"ClassWithAnyKindsOfClasses.java")
 									+ ":" + System.lineSeparator() + "  - Local-Class-Statement was found:"
@@ -432,7 +428,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoRecord_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration",
 											"testuser", "javaClassesWithUnsupportedFeatures", "classes", "yes",
 											"ClassWithAnyKindsOfUnsupportedClasses.java")
 									+ ":" + System.lineSeparator() + "  - Local-Record-Statement was found:"
@@ -457,7 +453,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoClass_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration",
 											"testuser", "javaClassesWithUnsupportedFeatures", "classes", "yes",
 											"ClassWithAnyKindsOfUnsupportedClasses.java")
 									+ ":" + System.lineSeparator() + "  - Local-Class-Statement was found:"
@@ -485,7 +481,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1, testFailedWith(testHasBelowNoAssertExceptionHandling_Fail,
 					AssertionError.class,
 					"Unwanted statement found:" + System.lineSeparator() + " - In "
-							+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration", "testuser",
+							+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration", "testuser",
 									"subject", "structural", "astTestFiles", "exceptionHandlings", "yes",
 									"ClassWithAnyKindsOfExceptionHandlings.java")
 							+ ":" + System.lineSeparator() + "  - Assert-Statement was found:" + System.lineSeparator()
@@ -509,7 +505,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoThrowExceptionHandling_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "exceptionHandlings",
 											"yes", "ClassWithAnyKindsOfExceptionHandlings.java")
 									+ ":" + System.lineSeparator() + "  - Throw-Statement was found:"
@@ -534,7 +530,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoCatchExceptionHandling_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "exceptionHandlings",
 											"yes", "ClassWithAnyKindsOfExceptionHandlings.java")
 									+ ":" + System.lineSeparator() + "  - Catch-Statement was found:"
@@ -559,7 +555,7 @@ public class AstAssertionTest {
 			tests.assertThatEvents().haveExactly(1,
 					testFailedWith(testHasBelowNoAnyExceptionHandling_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
-									+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "integration",
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
 											"testuser", "subject", "structural", "astTestFiles", "exceptionHandlings",
 											"yes", "ClassWithAnyKindsOfExceptionHandlings.java")
 									+ ":" + System.lineSeparator() + "  - Assert-Statement was found:"
@@ -576,32 +572,9 @@ public class AstAssertionTest {
 	class PomXmlTestTests {
 
 		@TestTest
-		void test_testDelocatedPomXmlFileDoesExist() {
-			String testDelocatedPomXmlFileDoesExist = "testDelocatedPomXmlFileDoesExist";
-			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testDelocatedPomXmlFileDoesExist));
-		}
-	}
-
-	@Nested
-	@DisplayName("UnwantedNodesAssert-Test-Tests")
-	class UnwantedNodesAssertTestTests {
-
-		@TestTest
-		void test_testAssertThatAllProjectSourcesAtPackage() {
-			String testAssertThatAllProjectSourcesAtPackage = "testAssertThatAllProjectSourcesAtPackage";
-			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testAssertThatAllProjectSourcesAtPackage));
-		}
-
-		@TestTest
-		void test_testAssertThatAllProjectSourcesAtPath() {
-			String testAssertThatAllProjectSourcesAtPath = "testAssertThatAllProjectSourcesAtPath";
-			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testAssertThatAllProjectSourcesAtPath));
-		}
-
-		@TestTest
-		void test_assertThatAllProjectSources() {
-			String assertThatAllProjectSources = "assertThatAllProjectSources";
-			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(assertThatAllProjectSources));
+		void test_testPomXmlFileDoesExist() {
+			String testPomXmlFileDoesExist = "testPomXmlFileDoesExist";
+			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testPomXmlFileDoesExist));
 		}
 	}
 
@@ -610,63 +583,52 @@ public class AstAssertionTest {
 	class ErrorTestTests {
 
 		@TestTest
-		void test_testRelativePathDoesNotExist() {
-			String testRelativePathDoesNotExist = "testRelativePathDoesNotExist";
-			tests.assertThatEvents()
-					.haveExactly(1,
-							testFailedWith(testRelativePathDoesNotExist, AssertionError.class,
-									"The path "
-											+ Path.of(".", "src", "test", "java", "de", "tum", "in", "test", "this",
-													"path", "does", "not", "exist")
-											+ " (resulting from the relativePackage de.tum.in.test, the relativePath "
-											+ Path.of("this", "path", "does", "not", "exist")
-											+ " and the delocatedBuildFile " + Path.of("src", "test", "resources", "de",
-													"tum", "in", "test", "integration", "testuser", "build.gradle")
-											+ ") does not exist."));
+		void test_testPathDoesNotExist() {
+			String testPathDoesNotExist = "testPathDoesNotExist";
+			tests.assertThatEvents().haveExactly(1, testFailedWith(testPathDoesNotExist, AssertionError.class,
+					"The source directory " + Path.of("this/path/does/not/exist") + " does not exist"));
 		}
 
 		@TestTest
-		void test_testRelativePathIsNull() {
-			String testRelativePathIsNull = "testRelativePathIsNull";
-			tests.assertThatEvents().haveExactly(1, testFailedWith(testRelativePathIsNull, AssertionError.class,
-					"The 'relativePath' must not be null."));
+		void test_testPathIsNull() {
+			String testPathIsNull = "testPathIsNull";
+			tests.assertThatEvents().haveExactly(1, testFailedWith(testPathIsNull, NullPointerException.class,
+					"The given source path must not be null."));
 		}
 
 		@TestTest
-		void test_testRelativePackageDoesNotExist() {
-			String testRelativePackageDoesNotExist = "testRelativePackageDoesNotExist";
+		void test_testPackageDoesNotExist() {
+			String testPackageDoesNotExist = "testPackageDoesNotExist";
 			tests.assertThatEvents().haveExactly(1,
-					testFailedWith(testRelativePackageDoesNotExist, AssertionError.class, "The path "
-							+ Path.of(".", "src", "test", "java", "this", "package", "name", "does", "not", "exist",
-									"integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-							+ " (resulting from the relativePackage this.package.name.does.not.exist, the relativePath "
-							+ Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-							+ " and the delocatedBuildFile " + Path.of("src", "test", "resources", "de", "tum", "in",
-									"test", "integration", "testuser", "build.gradle")
-							+ ") does not exist."));
+					testFailedWith(testPackageDoesNotExist, AssertionError.class, "The source directory "
+							+ Path.of("src/test/java/this/package/name/does/not/exist") + " does not exist"));
 		}
 
 		@TestTest
-		void test_testRelativePackageIsNull() {
-			String testRelativePackageIsNull = "testRelativePackageIsNull";
-			tests.assertThatEvents().haveExactly(1, testFailedWith(testRelativePackageIsNull, AssertionError.class,
-					"The 'relativePackage' must not be null."));
+		void test_testPackageIsNull() {
+			String testPackageIsNull = "testPackageIsNull";
+			tests.assertThatEvents().haveExactly(1, testFailedWith(testPackageIsNull, NullPointerException.class,
+					"The package name must not be null."));
 		}
 
 		@TestTest
-		void test_testDelocatedBuildGradleFileDoesNotExist() {
-			String testDelocatedBuildGradleFileDoesNotExist = "testDelocatedBuildGradleFileDoesNotExist";
+		void test_testBuildGradleFileDoesNotExist() {
+			String testBuildGradleFileDoesNotExist = "testBuildGradleFileDoesNotExist";
 			tests.assertThatEvents().haveExactly(1,
-					testFailedWith(testDelocatedBuildGradleFileDoesNotExist, AssertionError.class,
-							"The 'delocatedBuildFile' " + Path.of("this", "path", "does", "not", "exist")
-									+ " does not exist."));
+					testFailedWith(testBuildGradleFileDoesNotExist, AssertionError.class,
+							"Could not find project sources folder. Make sure the build file is configured correctly."
+									+ " If it is not located in the execution folder directly,"
+									+ " set the location using AresConfiguration methods."));
 		}
 
 		@TestTest
-		void test_testDelocatedBuildGradleFileIsNull() {
-			String testDelocatedBuildGradleFileIsNull = "testDelocatedBuildGradleFileIsNull";
-			tests.assertThatEvents().haveExactly(1, testFailedWith(testDelocatedBuildGradleFileIsNull,
-					AssertionError.class, "The 'delocatedBuildFile' must not be null."));
+		void test_testBuildGradleFileIsNull() {
+			String testBuildGradleFileIsNull = "testBuildGradleFileIsNull";
+			tests.assertThatEvents().haveExactly(1,
+					testFailedWith(testBuildGradleFileIsNull, AssertionError.class,
+							"Could not find project sources folder. Make sure the build file is configured correctly."
+									+ " If it is not located in the execution folder directly,"
+									+ " set the location using AresConfiguration methods."));
 		}
 
 		@TestTest

--- a/src/test/java/de/tum/in/test/integration/StructuralTest.java
+++ b/src/test/java/de/tum/in/test/integration/StructuralTest.java
@@ -199,6 +199,7 @@ class StructuralTest {
 	@TestTest
 	void test_noBuildToolFile() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(noBuildToolFile, AssertionFailedError.class,
-				"[[ERROR] Could not find any build file. Contact your instructor.]"));
+				"[[ERROR] Could not find any build file. Contact your instructor., "
+						+ "[ERROR] Could not retrieve source directory from project file. Contact your instructor.]"));
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/AstAssertionUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/AstAssertionUser.java
@@ -3,13 +3,11 @@ package de.tum.in.test.integration.testuser;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import com.github.javaparser.ParserConfiguration;
 
-import de.tum.in.test.api.StrictTimeout;
+import de.tum.in.test.api.*;
 import de.tum.in.test.api.ast.asserting.UnwantedNodesAssert;
 import de.tum.in.test.api.ast.type.*;
 import de.tum.in.test.api.jupiter.Public;
@@ -20,30 +18,39 @@ import de.tum.in.test.api.localization.UseLocale;
 @StrictTimeout(5)
 public class AstAssertionUser {
 
+	private static final String BASE_PACKAGE = "de.tum.in.test.integration.testuser.subject.structural.astTestFiles";
+	private static final Path UNSUPPORTED_LEVEL_BASE_PATH = Path.of("src", "test", "resources", "de", "tum", "in",
+			"test", "integration", "testuser", "javaClassesWithUnsupportedFeatures");
+
+	private String mavenOld;
+	private String gradleOld;
+
+	@BeforeEach
+	void configureProjectBuildFile() {
+		mavenOld = AresConfiguration.getPomXmlPath();
+		gradleOld = AresConfiguration.getBuildGradlePath();
+		AresConfiguration.setPomXmlPath(null);
+		AresConfiguration.setBuildGradlePath("src/test/resources/de/tum/in/test/integration/testuser/build.gradle");
+	}
+
+	@AfterEach
+	void unconfigureProjectBuildFile() {
+		AresConfiguration.setPomXmlPath(mavenOld);
+		AresConfiguration.setBuildGradlePath(gradleOld);
+	}
+
 	@Nested
 	@DisplayName("For-Loop-Tests")
 	class ForLoopTests {
 		@Test
 		void testHasBelowNoForLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
 		}
 
 		@Test
 		void testHasBelowNoForLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
 		}
 	}
@@ -53,25 +60,13 @@ public class AstAssertionUser {
 	class ForEachLoopTests {
 		@Test
 		void testHasBelowNoForEachLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
 		}
 
 		@Test
 		void testHasBelowNoForEachLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
 		}
 	}
@@ -81,25 +76,13 @@ public class AstAssertionUser {
 	class WhileLoopTests {
 		@Test
 		void testHasBelowNoWhileLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
 		}
 
 		@Test
 		void testHasBelowNoWhileLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
 		}
 	}
@@ -109,25 +92,13 @@ public class AstAssertionUser {
 	class DoWhileLoopTests {
 		@Test
 		void testHasBelowNoDoWhileLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
 		}
 
 		@Test
 		void testHasBelowNoDoWhileLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
 		}
 	}
@@ -137,25 +108,13 @@ public class AstAssertionUser {
 	class AnyForLoopTests {
 		@Test
 		void testHasBelowNoAnyForLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
 		}
 
 		@Test
 		void testHasBelowNoAnyForLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
 		}
 	}
@@ -165,25 +124,13 @@ public class AstAssertionUser {
 	class AnyWhileLoopTests {
 		@Test
 		void testHasBelowNoAnyWhileLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
 		}
 
 		@Test
 		void testHasBelowNoAnyWhileLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
 		}
 	}
@@ -193,25 +140,13 @@ public class AstAssertionUser {
 	class AnyLoopTests {
 		@Test
 		void testHasBelowNoAnyLoop_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
 		}
 
 		@Test
 		void testHasBelowNoAnyLoop_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "yes")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
 		}
 	}
@@ -221,25 +156,13 @@ public class AstAssertionUser {
 	class IfStatementTests {
 		@Test
 		void testHasBelowNoIfStatement_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
 		}
 
 		@Test
 		void testHasBelowNoIfStatement_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
 		}
 	}
@@ -249,26 +172,14 @@ public class AstAssertionUser {
 	class IfExpressionTests {
 		@Test
 		void testHasBelowNoIfExpression_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
 					.hasNo(ConditionalType.CONDITIONALEXPR);
 		}
 
 		@Test
 		void testHasBelowNoIfExpression_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
 					.hasNo(ConditionalType.CONDITIONALEXPR);
 		}
@@ -279,25 +190,13 @@ public class AstAssertionUser {
 	class SwitchStatementTests {
 		@Test
 		void testHasBelowNoSwitchStatement_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
 		}
 
 		@Test
 		void testHasBelowNoSwitchStatement_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
 		}
 	}
@@ -307,17 +206,13 @@ public class AstAssertionUser {
 	class SwitchExpressionTests {
 		@Test
 		void testHasBelowNoSwitchExpression_Success() throws IOException {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "no").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
 		}
 
 		@Test
 		void testHasBelowNoSwitchExpression_Fail() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "yes").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
 		}
 	}
@@ -327,25 +222,13 @@ public class AstAssertionUser {
 	class AnyIfTests {
 		@Test
 		void testHasBelowNoAnyIf_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
 		}
 
 		@Test
 		void testHasBelowNoAnyIf_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "conditionals",
-									"yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
 		}
 	}
@@ -355,17 +238,13 @@ public class AstAssertionUser {
 	class AnySwitchTests {
 		@Test
 		void testHasBelowNoAnySwitch_Success() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "no").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
 		}
 
 		@Test
 		void testHasBelowNoAnySwitch_Fail() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "yes").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
 		}
 	}
@@ -375,17 +254,13 @@ public class AstAssertionUser {
 	class AnyConditionalTests {
 		@Test
 		void testHasBelowNoAnyConditional_Success() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "no").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
 		}
 
 		@Test
 		void testHasBelowNoAnyConditional_Fail() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "conditionals", "yes").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
 		}
 	}
@@ -395,25 +270,13 @@ public class AstAssertionUser {
 	class ClassTests {
 		@Test
 		void testHasBelowNoClass_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "classes", "no")
-									.toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
 		}
 
 		@Test
 		void testHasBelowNoClass_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "classes",
-									"yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
 		}
 	}
@@ -423,17 +286,13 @@ public class AstAssertionUser {
 	class RecordTests {
 		@Test
 		void testHasBelowNoRecord_Success() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "classes", "no").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
 		}
 
 		@Test
 		void testHasBelowNoRecord_Fail() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "classes", "yes").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
 		}
 	}
@@ -443,17 +302,13 @@ public class AstAssertionUser {
 	class AnyClassTests {
 		@Test
 		void testHasBelowNoAnyClass_Success() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "classes", "no").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
 		}
 
 		@Test
 		void testHasBelowNoAnyClass_Fail() {
-			UnwantedNodesAssert
-					.assertThat(Path.of(".", "src", "test", "resources", "de", "tum", "in", "test", "integration",
-							"testuser", "javaClassesWithUnsupportedFeatures", "classes", "yes").toString())
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
 		}
 	}
@@ -463,25 +318,13 @@ public class AstAssertionUser {
 	class AssertExceptionHandlingTests {
 		@Test
 		void testHasBelowNoAssertExceptionHandling_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
 		}
 
 		@Test
 		void testHasBelowNoAssertExceptionHandling_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
 		}
 	}
@@ -491,25 +334,13 @@ public class AstAssertionUser {
 	class ThrowExceptionHandlingTests {
 		@Test
 		void testHasBelowNoThrowExceptionHandling_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
 		}
 
 		@Test
 		void testHasBelowNoThrowExceptionHandling_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
 		}
 	}
@@ -519,25 +350,13 @@ public class AstAssertionUser {
 	class CatchExceptionHandlingTests {
 		@Test
 		void testHasBelowNoCatchExceptionHandling_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
 		}
 
 		@Test
 		void testHasBelowNoCatchExceptionHandling_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
 		}
 	}
@@ -547,25 +366,13 @@ public class AstAssertionUser {
 	class AnyExceptionHandlingTests {
 		@Test
 		void testHasBelowNoAnyExceptionHandling_Success() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "no").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
 		}
 
 		@Test
 		void testHasBelowNoAnyExceptionHandling_Fail() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles",
-									"exceptionHandlings", "yes").toString())
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
 		}
 	}
@@ -574,48 +381,11 @@ public class AstAssertionUser {
 	@DisplayName("PomXml-Tests")
 	class PomXmlTests {
 		@Test
-		void testDelocatedPomXmlFileDoesExist() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"pom.xml").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+		void testPomXmlFileDoesExist() {
+			AresConfiguration.setBuildGradlePath(null);
+			AresConfiguration.setPomXmlPath("src/test/resources/de/tum/in/test/integration/testuser/pom.xml");
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-		}
-	}
-
-	@Nested
-	@DisplayName("UnwantedNodesAssert-Tests")
-	class UnwantedNodesAssertTests {
-		@Test
-		void testAssertThatAllProjectSourcesAtPackage() {
-			UnwantedNodesAssert
-					.assertThatAllProjectSourcesAtPackage(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test.integration.testuser.subject.structural.astTestFiles.loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
-
-		@Test
-		void testAssertThatAllProjectSourcesAtPath() {
-			UnwantedNodesAssert
-					.assertThatAllProjectSourcesAtPath(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							Path.of("de", "tum", "in", "test", "integration", "testuser", "subject", "structural",
-									"astTestFiles", "loops", "no").toString())
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
-
-		@Test
-		void assertThatAllProjectSources() {
-			UnwantedNodesAssert
-					.assertThatAllProjectSources(Path.of("src", "test", "resources", "de", "tum", "in", "test",
-							"integration", "testuser", "build.gradle").toString())
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
 		}
 	}
 
@@ -624,75 +394,46 @@ public class AstAssertionUser {
 	class ErrorTests {
 
 		@Test
-		void testRelativePathDoesNotExist() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"de.tum.in.test", Path.of("this", "path", "does", "not", "exist").toString())
+		void testPathDoesNotExist() {
+			UnwantedNodesAssert.assertThatSourcesIn(Path.of("this", "path", "does", "not", "exist"))
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
 		}
 
 		@Test
-		void testRelativePathIsNull() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(Path.of("src", "test", "resources", "de", "tum", "in", "test",
-							"integration", "testuser", "build.gradle").toString(), "de.tum.in.test", null)
+		void testPathIsNull() {
+			UnwantedNodesAssert.assertThatSourcesIn(null).withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
+
+		@Test
+		void testPackageDoesNotExist() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage("this.package.name.does.not.exist")
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
 		}
 
 		@Test
-		void testRelativePackageDoesNotExist() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							"this.package.name.does.not.exist",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
+		void testPackageIsNull() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(null)
 					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
 		}
 
 		@Test
-		void testRelativePackageIsNull() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(
-							Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-									"build.gradle").toString(),
-							null,
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		void testBuildGradleFileDoesNotExist() {
+			AresConfiguration.setBuildGradlePath("does/not/exist/build.bradle");
+			UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
 		}
 
 		@Test
-		void testDelocatedBuildGradleFileDoesNotExist() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(Path.of("this", "path", "does", "not", "exist").toString(),
-							"de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
-
-		@Test
-		void testDelocatedBuildGradleFileIsNull() {
-			UnwantedNodesAssert
-					.assertThatProjectSources(null, "de.tum.in.test",
-							Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-									.toString())
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		void testBuildGradleFileIsNull() {
+			AresConfiguration.setBuildGradlePath(null);
+			UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
 		}
 
 		@Test
 		void testLevelIsNull() {
-			UnwantedNodesAssert.assertThatProjectSources(
-					Path.of("src", "test", "resources", "de", "tum", "in", "test", "integration", "testuser",
-							"build.gradle").toString(),
-					"de.tum.in.test",
-					Path.of("integration", "testuser", "subject", "structural", "astTestFiles", "loops", "no")
-							.toString())
-					.withLanguageLevel(null).hasNo(LoopType.ANY);
+			UnwantedNodesAssert.assertThatProjectSources().hasNo(LoopType.ANY);
 		}
 	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/StructuralUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/StructuralUser.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URISyntaxException;
+import java.util.List;
 
 import org.junit.jupiter.api.*;
 import org.slf4j.LoggerFactory;
@@ -17,11 +18,13 @@ import de.tum.in.test.api.jupiter.Public;
 import de.tum.in.test.api.localization.UseLocale;
 import de.tum.in.test.api.structural.*;
 import de.tum.in.test.api.structural.testutils.ClassNameScanner;
+import de.tum.in.test.api.util.ProjectSourcesFinder;
 
 @Public
 @UseLocale("en")
 @StrictTimeout(10)
 @WhitelistPath("")
+@SuppressWarnings("deprecation")
 public class StructuralUser {
 
 	private static final String TESTUSER_POM_XML = "src/test/resources/de/tum/in/test/integration/testuser/pom.xml";
@@ -50,18 +53,19 @@ public class StructuralUser {
 	@Nested
 	class InvalidConfigurations {
 
-		private final Logger logger = ((Logger) LoggerFactory.getLogger(ClassNameScanner.class));
+		private final List<Logger> loggers = List.of((Logger) LoggerFactory.getLogger(ProjectSourcesFinder.class),
+				(Logger) LoggerFactory.getLogger(ClassNameScanner.class));
 		private final ListAppender<ILoggingEvent> logs = new ListAppender<>();
 
 		@BeforeEach
-		void addLogger() {
-			logger.addAppender(logs);
+		void addLoggers() {
+			loggers.forEach(logger -> logger.addAppender(logs));
 			logs.start();
 		}
 
 		@AfterEach
-		void removeLogger() {
-			logger.detachAppender(logs);
+		void removeLoggers() {
+			loggers.forEach(logger -> logger.detachAppender(logs));
 		}
 
 		@Test


### PR DESCRIPTION
- I added some Javadoc to public API classes.
- The tests stayed mostly the same, only the dot before relative paths got removed.
- The methods for project file configuration in `ClassNameScanner` got deprecated because they are not unique to the structural tests. I added a global utility class for Ares configuration.
- The ability for a relative path after the source path and the package got removed, unless we have a good reason to have so many ways to specify a simple path to a directory. (We need to maintain all of that carefully, so less is better, see the maintenance nightmare in `ReflectionTestUtils`)
- Number of lines in the Assertion halved
- Complexity for API users is reduced (test class only has 2/3 of the lines now, and a lot less strings and paths)