### PR TITLE
Added missing com/github/javaparser file-not-exsists rule in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -362,6 +362,7 @@ Maven:
                 <files>
                     <!--2-->
                     <file>${project.build.outputDirectory}/ch/qos/logback/</file>
+                    <file>${project.build.outputDirectory}/com/github/javaparser/</file>
                     <file>${project.build.outputDirectory}/com/intellij/</file>
                     <file>${project.build.outputDirectory}/com/sun/</file>
                     <file>${project.build.outputDirectory}/de/tum/in/test/api/</file>
@@ -392,6 +393,7 @@ Gradle:
 
 def forbiddenPackageFolders = [ //<2>
     "$studentOutputDir/ch/qos/logback/",
+    "$studentOutputDir/com/github/javaparser/",
     "$studentOutputDir/com/intellij/",
     "$studentOutputDir/com/sun/",
     "$studentOutputDir/de/tum/in/test/api/",


### PR DESCRIPTION
[`SecurityConstants`](https://github.com/ls1intum/Ares/blob/master/src/main/java/de/tum/in/test/api/security/SecurityConstants.java#L44C4-L44C27) lists `com.github.javaparser` as a trusted package, so [`AresSecurityConfigurationBuilder`](https://github.com/ls1intum/Ares/blob/master/src/main/java/de/tum/in/test/api/security/AresSecurityConfigurationBuilder.java#L192-L205) checks that that package is forbidden by a file-must-not-exist rule, but the template in the README does not list that package.