### PR TITLE
feat: Parameterized Public and Hidden Test annotations

### DIFF
--- a/src/main/java/de/tum/in/test/api/jupiter/ParameterizedHiddenTest.java
+++ b/src/main/java/de/tum/in/test/api/jupiter/ParameterizedHiddenTest.java
@@ -1,0 +1,36 @@
+package de.tum.in.test.api.jupiter;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.*;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import de.tum.in.test.api.Deadline;
+import de.tum.in.test.api.context.TestType;
+import de.tum.in.test.api.io.IOTester;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Marks a HIDDEN test case, can declare {@link IOTester} as parameter. This
+ * annotation requires a {@link Deadline} annotation to be set either on the
+ * test class or the test method. See {@link Deadline} for more information.
+ * Requires a {@link ValueSource} annotation.
+ *
+ * @author Ivan Kuzmin
+ * @version 1.1.0
+ * @see Deadline
+ * @since 0.13.0
+ */
+@API(status = Status.MAINTAINED)
+@Documented()
+@Retention(RUNTIME)
+@Target(METHOD)
+@ParameterizedTest
+@JupiterAresTest(TestType.HIDDEN)
+public @interface ParameterizedHiddenTest {
+    // maker only
+}

--- a/src/main/java/de/tum/in/test/api/jupiter/ParameterizedPublicTest.java
+++ b/src/main/java/de/tum/in/test/api/jupiter/ParameterizedPublicTest.java
@@ -1,0 +1,33 @@
+package de.tum.in.test.api.jupiter;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.*;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import de.tum.in.test.api.context.TestType;
+import de.tum.in.test.api.io.IOTester;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Marks a <b>PUBLIC</b> test case, uses the PdgpSecurityManager, can declare
+ * {@link IOTester} as parameter.
+ * Requires a {@link ValueSource} annotation.
+ *
+ * @author Ivan Kuzmin
+ * @version 1.1.0
+ * @since 0.13.0
+ */
+@API(status = Status.MAINTAINED)
+@Documented()
+@Retention(RUNTIME)
+@Target(METHOD)
+@ParameterizedTest
+@JupiterAresTest(TestType.PUBLIC)
+public @interface ParameterizedPublicTest {
+    // maker only
+}


### PR DESCRIPTION
I think it would be a good addition to have Parameterized test annotations, since it would allow to avoid helper methods usage / code duplication when testing several different input cases.

I am not sure whether the version numbers are correct.

Here is an example of what it would look like:

```java
public class Numbers {
    public static boolean isOdd(int number) {
        return number % 2 != 0;
    }
}

@ParameterizedPublicTest
@ValueSource(ints = {1, 3, 5, -3, 15, Integer.MAX_VALUE}) // six numbers
void isOdd_ShouldReturnTrueForOddNumbers(int number) {
    assertTrue(Numbers.isOdd(number));
}
```
(adapted from https://www.baeldung.com/parameterized-tests-junit-5)