### PR TITLE
Improve AST functionality with excludeMain()

### DIFF
--- a/src/main/java/de/tum/in/test/api/ast/asserting/UnwantedNodesAssert.java
+++ b/src/main/java/de/tum/in/test/api/ast/asserting/UnwantedNodesAssert.java
@@ -35,8 +35,7 @@ public class UnwantedNodesAssert extends AbstractAssert<UnwantedNodesAssert, Pat
 	private final LanguageLevel level;
 
 	/**
-	 * Whether to enable the main method for the Java parser
-	 * Default is set to false
+	 * Whether to enable the main method for the Java parser Default is set to false
 	 */
 	private final boolean excludeMainMethod;
 

--- a/src/main/java/de/tum/in/test/api/ast/model/JavaFile.java
+++ b/src/main/java/de/tum/in/test/api/ast/model/JavaFile.java
@@ -41,7 +41,7 @@ public class JavaFile {
 				.filter(method -> method.isStatic() && method.getNameAsString().equals("main")
 						&& method.getParameters().size() == 1 && method.getType().isVoidType()
 						&& method.getParameter(0).getTypeAsString().equals("String[]"))
-				.findAny().ifPresent(Node::remove);
+				.forEach(Node::remove);
 	}
 
 	public Path getJavaFilePath() {

--- a/src/main/java/de/tum/in/test/api/ast/model/JavaFile.java
+++ b/src/main/java/de/tum/in/test/api/ast/model/JavaFile.java
@@ -7,14 +7,14 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.stream.*;
 
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.*;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
 
 /**
  * Stores all required information about a Java file to be analyzed
@@ -37,11 +37,11 @@ public class JavaFile {
 	}
 
 	private static void excludeMainMethod(CompilationUnit javaFileAST) {
-		javaFileAST.findAll(MethodDeclaration.class)
-				.stream()
-				.filter(method -> method.isStatic() && method.getNameAsString().equals("main") && method.getParameters().size() == 1 && method.getType().isVoidType() && method.getParameter(0).getTypeAsString().equals("String[]"))
-				.findAny()
-				.ifPresent(Node::remove);
+		javaFileAST.findAll(MethodDeclaration.class).stream()
+				.filter(method -> method.isStatic() && method.getNameAsString().equals("main")
+						&& method.getParameters().size() == 1 && method.getType().isVoidType()
+						&& method.getParameter(0).getTypeAsString().equals("String[]"))
+				.findAny().ifPresent(Node::remove);
 	}
 
 	public Path getJavaFilePath() {

--- a/src/main/java/de/tum/in/test/api/ast/model/JavaFile.java
+++ b/src/main/java/de/tum/in/test/api/ast/model/JavaFile.java
@@ -7,6 +7,8 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.stream.*;
 
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.*;
@@ -26,9 +28,20 @@ public class JavaFile {
 	private final Path javaFilePath;
 	private final CompilationUnit javaFileAST;
 
-	public JavaFile(Path javaFilePath, CompilationUnit javaFileAST) {
+	public JavaFile(Path javaFilePath, CompilationUnit javaFileAST, boolean excludeMainMethod) {
 		this.javaFilePath = javaFilePath;
+		if (excludeMainMethod) {
+			excludeMainMethod(javaFileAST);
+		}
 		this.javaFileAST = javaFileAST;
+	}
+
+	private static void excludeMainMethod(CompilationUnit javaFileAST) {
+		javaFileAST.findAll(MethodDeclaration.class)
+				.stream()
+				.filter(method -> method.isStatic() && method.getNameAsString().equals("main") && method.getParameters().size() == 1 && method.getType().isVoidType() && method.getParameter(0).getTypeAsString().equals("String[]"))
+				.findAny()
+				.ifPresent(Node::remove);
 	}
 
 	public Path getJavaFilePath() {
@@ -47,12 +60,12 @@ public class JavaFile {
 	 * @return The information of the Java-file packed into a JavaFile object (null
 	 *         if the file is not a Java-file)
 	 */
-	public static JavaFile convertFromFile(Path pathOfFile) {
+	public static JavaFile convertFromFile(Path pathOfFile, Boolean excludeMainMethod) {
 		if (!JAVAFILEMATCHER.matches(pathOfFile.getFileName())) {
 			return null;
 		}
 		try {
-			return new JavaFile(pathOfFile, StaticJavaParser.parse(pathOfFile));
+			return new JavaFile(pathOfFile, StaticJavaParser.parse(pathOfFile), excludeMainMethod);
 		} catch (IOException e) {
 			LOG.error("Error reading Java file '{}'", pathOfFile.toAbsolutePath(), e); //$NON-NLS-1$
 			throw new AssertionError(localized("ast.method.convert_from_file", pathOfFile.toAbsolutePath()));
@@ -67,9 +80,9 @@ public class JavaFile {
 	 *         list if the directory does not exist or if none of the files in the
 	 *         directory or its subdirectories is a Java-file)
 	 */
-	public static List<JavaFile> readFromDirectory(Path pathOfDirectory) {
+	public static List<JavaFile> readFromDirectory(Path pathOfDirectory, boolean excludeMainMethod) {
 		try (Stream<Path> directoryContentStream = Files.walk(pathOfDirectory)) {
-			return directoryContentStream.map(JavaFile::convertFromFile).filter(Objects::nonNull)
+			return directoryContentStream.map(path -> convertFromFile(path, excludeMainMethod)).filter(Objects::nonNull)
 					.collect(Collectors.toList());
 		} catch (IOException e) {
 			LOG.error("Error reading Java files in '{}'", pathOfDirectory.toAbsolutePath(), e); //$NON-NLS-1$

--- a/src/main/java/de/tum/in/test/api/ast/model/UnwantedNode.java
+++ b/src/main/java/de/tum/in/test/api/ast/model/UnwantedNode.java
@@ -43,7 +43,7 @@ public class UnwantedNode {
 	 *                               UnwantedNode objects)
 	 */
 	public static List<UnwantedNode> getUnwantedNodesInJavaFile(JavaFile javaFile,
-																Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
+			Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
 		return nodesDefinedAsUnwanted.keySet().stream()
 				.map(unwantedNodeName -> new UnwantedNode(javaFile, unwantedNodeName,
 						nodesDefinedAsUnwanted.get(unwantedNodeName)))
@@ -62,7 +62,7 @@ public class UnwantedNode {
 	 *         information (packed into UnwantedNode objects)
 	 */
 	public static Map<Path, List<UnwantedNode>> getUnwantedNodesForFileAt(Path pathOfJavaFile,
-																		  Map<String, Class<? extends Node>> nodesDefinedAsUnwanted, boolean excludeMainMethod) {
+			Map<String, Class<? extends Node>> nodesDefinedAsUnwanted, boolean excludeMainMethod) {
 		JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile, excludeMainMethod);
 		if (javaFile == null) {
 			return Map.of();
@@ -113,9 +113,9 @@ public class UnwantedNode {
 	 * @return Error message
 	 */
 	public static Optional<String> getMessageForUnwantedNodesForFileAt(Path pathOfJavaFile,
-																	   Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
-		Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile,
-				nodeNameUnwantedNodeMap, excludeMainMethod);
+			Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+		Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile, nodeNameUnwantedNodeMap,
+				excludeMainMethod);
 		if (unwantedNodes.isEmpty()) {
 			return Optional.empty();
 		}
@@ -132,7 +132,7 @@ public class UnwantedNode {
 	 * @return Error message
 	 */
 	public static Optional<String> getMessageForUnwantedNodesForAllFilesBelow(Path pathOfDirectory,
-																			  Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+			Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
 		return JavaFile.readFromDirectory(pathOfDirectory, excludeMainMethod).stream()
 				.sorted(Comparator.comparing(JavaFile::getJavaFilePath))
 				.map(javaFile -> getMessageForUnwantedNodesForFileAt(javaFile.getJavaFilePath(),

--- a/src/main/java/de/tum/in/test/api/ast/model/UnwantedNode.java
+++ b/src/main/java/de/tum/in/test/api/ast/model/UnwantedNode.java
@@ -43,7 +43,7 @@ public class UnwantedNode {
 	 *                               UnwantedNode objects)
 	 */
 	public static List<UnwantedNode> getUnwantedNodesInJavaFile(JavaFile javaFile,
-			Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
+																Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
 		return nodesDefinedAsUnwanted.keySet().stream()
 				.map(unwantedNodeName -> new UnwantedNode(javaFile, unwantedNodeName,
 						nodesDefinedAsUnwanted.get(unwantedNodeName)))
@@ -62,8 +62,8 @@ public class UnwantedNode {
 	 *         information (packed into UnwantedNode objects)
 	 */
 	public static Map<Path, List<UnwantedNode>> getUnwantedNodesForFileAt(Path pathOfJavaFile,
-			Map<String, Class<? extends Node>> nodesDefinedAsUnwanted) {
-		JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile);
+																		  Map<String, Class<? extends Node>> nodesDefinedAsUnwanted, boolean excludeMainMethod) {
+		JavaFile javaFile = JavaFile.convertFromFile(pathOfJavaFile, excludeMainMethod);
 		if (javaFile == null) {
 			return Map.of();
 		}
@@ -113,9 +113,9 @@ public class UnwantedNode {
 	 * @return Error message
 	 */
 	public static Optional<String> getMessageForUnwantedNodesForFileAt(Path pathOfJavaFile,
-			Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap) {
+																	   Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
 		Map<Path, List<UnwantedNode>> unwantedNodes = getUnwantedNodesForFileAt(pathOfJavaFile,
-				nodeNameUnwantedNodeMap);
+				nodeNameUnwantedNodeMap, excludeMainMethod);
 		if (unwantedNodes.isEmpty()) {
 			return Optional.empty();
 		}
@@ -132,11 +132,11 @@ public class UnwantedNode {
 	 * @return Error message
 	 */
 	public static Optional<String> getMessageForUnwantedNodesForAllFilesBelow(Path pathOfDirectory,
-			Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap) {
-		return JavaFile.readFromDirectory(pathOfDirectory).stream()
+																			  Map<String, Class<? extends Node>> nodeNameUnwantedNodeMap, boolean excludeMainMethod) {
+		return JavaFile.readFromDirectory(pathOfDirectory, excludeMainMethod).stream()
 				.sorted(Comparator.comparing(JavaFile::getJavaFilePath))
 				.map(javaFile -> getMessageForUnwantedNodesForFileAt(javaFile.getJavaFilePath(),
-						nodeNameUnwantedNodeMap))
+						nodeNameUnwantedNodeMap, excludeMainMethod))
 				.filter(Optional::isPresent).map(Optional::get).map(message -> message + System.lineSeparator())
 				.reduce(String::concat).map(String::trim).map(message -> " " + message);
 	}

--- a/src/test/java/de/tum/in/test/integration/AstAssertionTest.java
+++ b/src/test/java/de/tum/in/test/integration/AstAssertionTest.java
@@ -656,8 +656,8 @@ public class AstAssertionTest {
 					testFailedWith(testExcludeMain_Fail, AssertionError.class,
 							"Unwanted statement found:" + System.lineSeparator() + " - In "
 									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
-									"testuser", "subject", "structural", "astTestFiles", "excludeMain", "yes",
-									"ClassWithLoopOutsideMainMethod.java")
+											"testuser", "subject", "structural", "astTestFiles", "excludeMain", "yes",
+											"ClassWithLoopOutsideMainMethod.java")
 									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
 									+ System.lineSeparator() + "   - Between line 6 (column 3) and line 8 (column 3)"));
 		}

--- a/src/test/java/de/tum/in/test/integration/AstAssertionTest.java
+++ b/src/test/java/de/tum/in/test/integration/AstAssertionTest.java
@@ -638,4 +638,28 @@ public class AstAssertionTest {
 					"The 'level' is not set. Please use UnwantedNodesAssert.withLanguageLevel(LanguageLevel)."));
 		}
 	}
+
+	@Nested
+	@DisplayName("Exclude-Main-Test-Tests")
+	class ExcludeMainTestTests {
+
+		@TestTest
+		void test_testExcludeMain_Success() {
+			String testExcludeMain_Success = "testHasBelowNoLoopsOutsideMainMethod_Success";
+			tests.assertThatEvents().haveExactly(1, finishedSuccessfully(testExcludeMain_Success));
+		}
+
+		@TestTest
+		void test_testExcludeMain_Fail() {
+			String testExcludeMain_Fail = "testHasBelowNoLoopsOutsideMainMethod_Fail";
+			tests.assertThatEvents().haveExactly(1,
+					testFailedWith(testExcludeMain_Fail, AssertionError.class,
+							"Unwanted statement found:" + System.lineSeparator() + " - In "
+									+ Path.of("src", "test", "java", "de", "tum", "in", "test", "integration",
+									"testuser", "subject", "structural", "astTestFiles", "excludeMain", "yes",
+									"ClassWithLoopOutsideMainMethod.java")
+									+ ":" + System.lineSeparator() + "  - For-Statement was found:"
+									+ System.lineSeparator() + "   - Between line 6 (column 3) and line 8 (column 3)"));
+		}
+	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/AstAssertionUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/AstAssertionUser.java
@@ -18,440 +18,440 @@ import de.tum.in.test.api.localization.UseLocale;
 @StrictTimeout(5)
 public class AstAssertionUser {
 
-    private static final String BASE_PACKAGE = "de.tum.in.test.integration.testuser.subject.structural.astTestFiles";
-    private static final Path UNSUPPORTED_LEVEL_BASE_PATH = Path.of("src", "test", "resources", "de", "tum", "in",
-            "test", "integration", "testuser", "javaClassesWithUnsupportedFeatures");
+	private static final String BASE_PACKAGE = "de.tum.in.test.integration.testuser.subject.structural.astTestFiles";
+	private static final Path UNSUPPORTED_LEVEL_BASE_PATH = Path.of("src", "test", "resources", "de", "tum", "in",
+			"test", "integration", "testuser", "javaClassesWithUnsupportedFeatures");
 
-    private String mavenOld;
-    private String gradleOld;
+	private String mavenOld;
+	private String gradleOld;
 
-    @BeforeEach
-    void configureProjectBuildFile() {
-        mavenOld = AresConfiguration.getPomXmlPath();
-        gradleOld = AresConfiguration.getBuildGradlePath();
-        AresConfiguration.setPomXmlPath(null);
-        AresConfiguration.setBuildGradlePath("src/test/resources/de/tum/in/test/integration/testuser/build.gradle");
-    }
+	@BeforeEach
+	void configureProjectBuildFile() {
+		mavenOld = AresConfiguration.getPomXmlPath();
+		gradleOld = AresConfiguration.getBuildGradlePath();
+		AresConfiguration.setPomXmlPath(null);
+		AresConfiguration.setBuildGradlePath("src/test/resources/de/tum/in/test/integration/testuser/build.gradle");
+	}
 
-    @AfterEach
-    void unconfigureProjectBuildFile() {
-        AresConfiguration.setPomXmlPath(mavenOld);
-        AresConfiguration.setBuildGradlePath(gradleOld);
-    }
+	@AfterEach
+	void unconfigureProjectBuildFile() {
+		AresConfiguration.setPomXmlPath(mavenOld);
+		AresConfiguration.setBuildGradlePath(gradleOld);
+	}
 
-    @Nested
-    @DisplayName("For-Loop-Tests")
-    class ForLoopTests {
-        @Test
-        void testHasBelowNoForLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-        }
+	@Nested
+	@DisplayName("For-Loop-Tests")
+	class ForLoopTests {
+		@Test
+		void testHasBelowNoForLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
+		}
 
-        @Test
-        void testHasBelowNoForLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-        }
-    }
+		@Test
+		void testHasBelowNoForLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("For-Each-Loop-Tests")
-    class ForEachLoopTests {
-        @Test
-        void testHasBelowNoForEachLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
-        }
+	@Nested
+	@DisplayName("For-Each-Loop-Tests")
+	class ForEachLoopTests {
+		@Test
+		void testHasBelowNoForEachLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
+		}
 
-        @Test
-        void testHasBelowNoForEachLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
-        }
-    }
+		@Test
+		void testHasBelowNoForEachLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("While-Loop-Tests")
-    class WhileLoopTests {
-        @Test
-        void testHasBelowNoWhileLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
-        }
+	@Nested
+	@DisplayName("While-Loop-Tests")
+	class WhileLoopTests {
+		@Test
+		void testHasBelowNoWhileLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
+		}
 
-        @Test
-        void testHasBelowNoWhileLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
-        }
-    }
+		@Test
+		void testHasBelowNoWhileLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("Do-While-Loop-Tests")
-    class DoWhileLoopTests {
-        @Test
-        void testHasBelowNoDoWhileLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
-        }
+	@Nested
+	@DisplayName("Do-While-Loop-Tests")
+	class DoWhileLoopTests {
+		@Test
+		void testHasBelowNoDoWhileLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
+		}
 
-        @Test
-        void testHasBelowNoDoWhileLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
-        }
-    }
+		@Test
+		void testHasBelowNoDoWhileLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-For-Loop-Tests")
-    class AnyForLoopTests {
-        @Test
-        void testHasBelowNoAnyForLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
-        }
+	@Nested
+	@DisplayName("Any-For-Loop-Tests")
+	class AnyForLoopTests {
+		@Test
+		void testHasBelowNoAnyForLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
+		}
 
-        @Test
-        void testHasBelowNoAnyForLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyForLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-While-Loop-Tests")
-    class AnyWhileLoopTests {
-        @Test
-        void testHasBelowNoAnyWhileLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
-        }
+	@Nested
+	@DisplayName("Any-While-Loop-Tests")
+	class AnyWhileLoopTests {
+		@Test
+		void testHasBelowNoAnyWhileLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
+		}
 
-        @Test
-        void testHasBelowNoAnyWhileLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyWhileLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-Loop-Tests")
-    class AnyLoopTests {
-        @Test
-        void testHasBelowNoAnyLoop_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
+	@Nested
+	@DisplayName("Any-Loop-Tests")
+	class AnyLoopTests {
+		@Test
+		void testHasBelowNoAnyLoop_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testHasBelowNoAnyLoop_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyLoop_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		}
+	}
 
-    @Nested
-    @DisplayName("If-Statement-Tests")
-    class IfStatementTests {
-        @Test
-        void testHasBelowNoIfStatement_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
-        }
+	@Nested
+	@DisplayName("If-Statement-Tests")
+	class IfStatementTests {
+		@Test
+		void testHasBelowNoIfStatement_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
+		}
 
-        @Test
-        void testHasBelowNoIfStatement_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
-        }
-    }
+		@Test
+		void testHasBelowNoIfStatement_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("If-Expression-Tests")
-    class IfExpressionTests {
-        @Test
-        void testHasBelowNoIfExpression_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-                    .hasNo(ConditionalType.CONDITIONALEXPR);
-        }
+	@Nested
+	@DisplayName("If-Expression-Tests")
+	class IfExpressionTests {
+		@Test
+		void testHasBelowNoIfExpression_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(ConditionalType.CONDITIONALEXPR);
+		}
 
-        @Test
-        void testHasBelowNoIfExpression_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-                    .hasNo(ConditionalType.CONDITIONALEXPR);
-        }
-    }
+		@Test
+		void testHasBelowNoIfExpression_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(ConditionalType.CONDITIONALEXPR);
+		}
+	}
 
-    @Nested
-    @DisplayName("Switch-Statement-Tests")
-    class SwitchStatementTests {
-        @Test
-        void testHasBelowNoSwitchStatement_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
-        }
+	@Nested
+	@DisplayName("Switch-Statement-Tests")
+	class SwitchStatementTests {
+		@Test
+		void testHasBelowNoSwitchStatement_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
+		}
 
-        @Test
-        void testHasBelowNoSwitchStatement_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
-        }
-    }
+		@Test
+		void testHasBelowNoSwitchStatement_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("Switch-Expression-Tests")
-    class SwitchExpressionTests {
-        @Test
-        void testHasBelowNoSwitchExpression_Success() throws IOException {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
-        }
+	@Nested
+	@DisplayName("Switch-Expression-Tests")
+	class SwitchExpressionTests {
+		@Test
+		void testHasBelowNoSwitchExpression_Success() throws IOException {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
+		}
 
-        @Test
-        void testHasBelowNoSwitchExpression_Fail() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
-        }
-    }
+		@Test
+		void testHasBelowNoSwitchExpression_Fail() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-If-Tests")
-    class AnyIfTests {
-        @Test
-        void testHasBelowNoAnyIf_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
-        }
+	@Nested
+	@DisplayName("Any-If-Tests")
+	class AnyIfTests {
+		@Test
+		void testHasBelowNoAnyIf_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
+		}
 
-        @Test
-        void testHasBelowNoAnyIf_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyIf_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-Switch-Tests")
-    class AnySwitchTests {
-        @Test
-        void testHasBelowNoAnySwitch_Success() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
-        }
+	@Nested
+	@DisplayName("Any-Switch-Tests")
+	class AnySwitchTests {
+		@Test
+		void testHasBelowNoAnySwitch_Success() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
+		}
 
-        @Test
-        void testHasBelowNoAnySwitch_Fail() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
-        }
-    }
+		@Test
+		void testHasBelowNoAnySwitch_Fail() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-Conditional-Tests")
-    class AnyConditionalTests {
-        @Test
-        void testHasBelowNoAnyConditional_Success() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
-        }
+	@Nested
+	@DisplayName("Any-Conditional-Tests")
+	class AnyConditionalTests {
+		@Test
+		void testHasBelowNoAnyConditional_Success() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
+		}
 
-        @Test
-        void testHasBelowNoAnyConditional_Fail() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyConditional_Fail() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
+		}
+	}
 
-    @Nested
-    @DisplayName("Class-Tests")
-    class ClassTests {
-        @Test
-        void testHasBelowNoClass_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
-        }
+	@Nested
+	@DisplayName("Class-Tests")
+	class ClassTests {
+		@Test
+		void testHasBelowNoClass_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
+		}
 
-        @Test
-        void testHasBelowNoClass_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
-        }
-    }
+		@Test
+		void testHasBelowNoClass_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
+		}
+	}
 
-    @Nested
-    @DisplayName("Record-Tests")
-    class RecordTests {
-        @Test
-        void testHasBelowNoRecord_Success() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
-        }
+	@Nested
+	@DisplayName("Record-Tests")
+	class RecordTests {
+		@Test
+		void testHasBelowNoRecord_Success() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
+		}
 
-        @Test
-        void testHasBelowNoRecord_Fail() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
-        }
-    }
+		@Test
+		void testHasBelowNoRecord_Fail() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-Class-Tests")
-    class AnyClassTests {
-        @Test
-        void testHasBelowNoAnyClass_Success() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
-        }
+	@Nested
+	@DisplayName("Any-Class-Tests")
+	class AnyClassTests {
+		@Test
+		void testHasBelowNoAnyClass_Success() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
+		}
 
-        @Test
-        void testHasBelowNoAnyClass_Fail() {
-            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyClass_Fail() {
+			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
+		}
+	}
 
-    @Nested
-    @DisplayName("Assert-Exception-Handling-Tests")
-    class AssertExceptionHandlingTests {
-        @Test
-        void testHasBelowNoAssertExceptionHandling_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
-        }
+	@Nested
+	@DisplayName("Assert-Exception-Handling-Tests")
+	class AssertExceptionHandlingTests {
+		@Test
+		void testHasBelowNoAssertExceptionHandling_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
+		}
 
-        @Test
-        void testHasBelowNoAssertExceptionHandling_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
-        }
-    }
+		@Test
+		void testHasBelowNoAssertExceptionHandling_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
+		}
+	}
 
-    @Nested
-    @DisplayName("Throw-Exception-Handling-Tests")
-    class ThrowExceptionHandlingTests {
-        @Test
-        void testHasBelowNoThrowExceptionHandling_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
-        }
+	@Nested
+	@DisplayName("Throw-Exception-Handling-Tests")
+	class ThrowExceptionHandlingTests {
+		@Test
+		void testHasBelowNoThrowExceptionHandling_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
+		}
 
-        @Test
-        void testHasBelowNoThrowExceptionHandling_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
-        }
-    }
+		@Test
+		void testHasBelowNoThrowExceptionHandling_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
+		}
+	}
 
-    @Nested
-    @DisplayName("Catch-Exception-Handling-Tests")
-    class CatchExceptionHandlingTests {
-        @Test
-        void testHasBelowNoCatchExceptionHandling_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
-        }
+	@Nested
+	@DisplayName("Catch-Exception-Handling-Tests")
+	class CatchExceptionHandlingTests {
+		@Test
+		void testHasBelowNoCatchExceptionHandling_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
+		}
 
-        @Test
-        void testHasBelowNoCatchExceptionHandling_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
-        }
-    }
+		@Test
+		void testHasBelowNoCatchExceptionHandling_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
+		}
+	}
 
-    @Nested
-    @DisplayName("Any-Exception-Handling-Tests")
-    class AnyExceptionHandlingTests {
-        @Test
-        void testHasBelowNoAnyExceptionHandling_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
-        }
+	@Nested
+	@DisplayName("Any-Exception-Handling-Tests")
+	class AnyExceptionHandlingTests {
+		@Test
+		void testHasBelowNoAnyExceptionHandling_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
+		}
 
-        @Test
-        void testHasBelowNoAnyExceptionHandling_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
-        }
-    }
+		@Test
+		void testHasBelowNoAnyExceptionHandling_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
+		}
+	}
 
-    @Nested
-    @DisplayName("PomXml-Tests")
-    class PomXmlTests {
-        @Test
-        void testPomXmlFileDoesExist() {
-            AresConfiguration.setBuildGradlePath(null);
-            AresConfiguration.setPomXmlPath("src/test/resources/de/tum/in/test/integration/testuser/pom.xml");
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-        }
-    }
+	@Nested
+	@DisplayName("PomXml-Tests")
+	class PomXmlTests {
+		@Test
+		void testPomXmlFileDoesExist() {
+			AresConfiguration.setBuildGradlePath(null);
+			AresConfiguration.setPomXmlPath("src/test/resources/de/tum/in/test/integration/testuser/pom.xml");
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
+		}
+	}
 
-    @Nested
-    @DisplayName("Error-Tests")
-    class ErrorTests {
+	@Nested
+	@DisplayName("Error-Tests")
+	class ErrorTests {
 
-        @Test
-        void testPathDoesNotExist() {
-            UnwantedNodesAssert.assertThatSourcesIn(Path.of("this", "path", "does", "not", "exist"))
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
+		@Test
+		void testPathDoesNotExist() {
+			UnwantedNodesAssert.assertThatSourcesIn(Path.of("this", "path", "does", "not", "exist"))
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testPathIsNull() {
-            UnwantedNodesAssert.assertThatSourcesIn(null).withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-                    .hasNo(LoopType.ANY);
-        }
+		@Test
+		void testPathIsNull() {
+			UnwantedNodesAssert.assertThatSourcesIn(null).withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testPackageDoesNotExist() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage("this.package.name.does.not.exist")
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
+		@Test
+		void testPackageDoesNotExist() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage("this.package.name.does.not.exist")
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testPackageIsNull() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(null)
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
+		@Test
+		void testPackageIsNull() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(null)
+					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testBuildGradleFileDoesNotExist() {
-            AresConfiguration.setBuildGradlePath("does/not/exist/build.bradle");
-            UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-                    .hasNo(LoopType.ANY);
-        }
+		@Test
+		void testBuildGradleFileDoesNotExist() {
+			AresConfiguration.setBuildGradlePath("does/not/exist/build.bradle");
+			UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testBuildGradleFileIsNull() {
-            AresConfiguration.setBuildGradlePath(null);
-            UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-                    .hasNo(LoopType.ANY);
-        }
+		@Test
+		void testBuildGradleFileIsNull() {
+			AresConfiguration.setBuildGradlePath(null);
+			UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testLevelIsNull() {
-            UnwantedNodesAssert.assertThatProjectSources().hasNo(LoopType.ANY);
-        }
-    }
+		@Test
+		void testLevelIsNull() {
+			UnwantedNodesAssert.assertThatProjectSources().hasNo(LoopType.ANY);
+		}
+	}
 
-    @Nested
-    @DisplayName("Exclude-Main-Tests")
-    class ExcludeErrorTests {
-        @Test
-        void testHasBelowNoLoopsOutsideMainMethod_Success() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.no")
-                    .excludeMainMethod()
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
+	@Nested
+	@DisplayName("Exclude-Main-Tests")
+	class ExcludeErrorTests {
+		@Test
+		void testHasBelowNoLoopsOutsideMainMethod_Success() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.no")
+					.excludeMainMethod().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
 
-        @Test
-        void testHasBelowNoLoopsOutsideMainMethod_Fail() {
-            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.yes")
-                    .excludeMainMethod()
-                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-        }
-    }
+		@Test
+		void testHasBelowNoLoopsOutsideMainMethod_Fail() {
+			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.yes")
+					.excludeMainMethod().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+					.hasNo(LoopType.ANY);
+		}
+	}
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/AstAssertionUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/AstAssertionUser.java
@@ -18,422 +18,440 @@ import de.tum.in.test.api.localization.UseLocale;
 @StrictTimeout(5)
 public class AstAssertionUser {
 
-	private static final String BASE_PACKAGE = "de.tum.in.test.integration.testuser.subject.structural.astTestFiles";
-	private static final Path UNSUPPORTED_LEVEL_BASE_PATH = Path.of("src", "test", "resources", "de", "tum", "in",
-			"test", "integration", "testuser", "javaClassesWithUnsupportedFeatures");
+    private static final String BASE_PACKAGE = "de.tum.in.test.integration.testuser.subject.structural.astTestFiles";
+    private static final Path UNSUPPORTED_LEVEL_BASE_PATH = Path.of("src", "test", "resources", "de", "tum", "in",
+            "test", "integration", "testuser", "javaClassesWithUnsupportedFeatures");
 
-	private String mavenOld;
-	private String gradleOld;
+    private String mavenOld;
+    private String gradleOld;
 
-	@BeforeEach
-	void configureProjectBuildFile() {
-		mavenOld = AresConfiguration.getPomXmlPath();
-		gradleOld = AresConfiguration.getBuildGradlePath();
-		AresConfiguration.setPomXmlPath(null);
-		AresConfiguration.setBuildGradlePath("src/test/resources/de/tum/in/test/integration/testuser/build.gradle");
-	}
+    @BeforeEach
+    void configureProjectBuildFile() {
+        mavenOld = AresConfiguration.getPomXmlPath();
+        gradleOld = AresConfiguration.getBuildGradlePath();
+        AresConfiguration.setPomXmlPath(null);
+        AresConfiguration.setBuildGradlePath("src/test/resources/de/tum/in/test/integration/testuser/build.gradle");
+    }
 
-	@AfterEach
-	void unconfigureProjectBuildFile() {
-		AresConfiguration.setPomXmlPath(mavenOld);
-		AresConfiguration.setBuildGradlePath(gradleOld);
-	}
+    @AfterEach
+    void unconfigureProjectBuildFile() {
+        AresConfiguration.setPomXmlPath(mavenOld);
+        AresConfiguration.setBuildGradlePath(gradleOld);
+    }
 
-	@Nested
-	@DisplayName("For-Loop-Tests")
-	class ForLoopTests {
-		@Test
-		void testHasBelowNoForLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-		}
+    @Nested
+    @DisplayName("For-Loop-Tests")
+    class ForLoopTests {
+        @Test
+        void testHasBelowNoForLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
+        }
 
-		@Test
-		void testHasBelowNoForLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-		}
-	}
+        @Test
+        void testHasBelowNoForLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("For-Each-Loop-Tests")
-	class ForEachLoopTests {
-		@Test
-		void testHasBelowNoForEachLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
-		}
+    @Nested
+    @DisplayName("For-Each-Loop-Tests")
+    class ForEachLoopTests {
+        @Test
+        void testHasBelowNoForEachLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
+        }
 
-		@Test
-		void testHasBelowNoForEachLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
-		}
-	}
+        @Test
+        void testHasBelowNoForEachLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FOR_EACHSTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("While-Loop-Tests")
-	class WhileLoopTests {
-		@Test
-		void testHasBelowNoWhileLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
-		}
+    @Nested
+    @DisplayName("While-Loop-Tests")
+    class WhileLoopTests {
+        @Test
+        void testHasBelowNoWhileLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
+        }
 
-		@Test
-		void testHasBelowNoWhileLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
-		}
-	}
+        @Test
+        void testHasBelowNoWhileLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.WHILESTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("Do-While-Loop-Tests")
-	class DoWhileLoopTests {
-		@Test
-		void testHasBelowNoDoWhileLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
-		}
+    @Nested
+    @DisplayName("Do-While-Loop-Tests")
+    class DoWhileLoopTests {
+        @Test
+        void testHasBelowNoDoWhileLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
+        }
 
-		@Test
-		void testHasBelowNoDoWhileLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
-		}
-	}
+        @Test
+        void testHasBelowNoDoWhileLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.DO_WHILESTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-For-Loop-Tests")
-	class AnyForLoopTests {
-		@Test
-		void testHasBelowNoAnyForLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
-		}
+    @Nested
+    @DisplayName("Any-For-Loop-Tests")
+    class AnyForLoopTests {
+        @Test
+        void testHasBelowNoAnyForLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
+        }
 
-		@Test
-		void testHasBelowNoAnyForLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyForLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_FOR);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-While-Loop-Tests")
-	class AnyWhileLoopTests {
-		@Test
-		void testHasBelowNoAnyWhileLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
-		}
+    @Nested
+    @DisplayName("Any-While-Loop-Tests")
+    class AnyWhileLoopTests {
+        @Test
+        void testHasBelowNoAnyWhileLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
+        }
 
-		@Test
-		void testHasBelowNoAnyWhileLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyWhileLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY_WHILE);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-Loop-Tests")
-	class AnyLoopTests {
-		@Test
-		void testHasBelowNoAnyLoop_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
+    @Nested
+    @DisplayName("Any-Loop-Tests")
+    class AnyLoopTests {
+        @Test
+        void testHasBelowNoAnyLoop_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testHasBelowNoAnyLoop_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyLoop_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
+    }
 
-	@Nested
-	@DisplayName("If-Statement-Tests")
-	class IfStatementTests {
-		@Test
-		void testHasBelowNoIfStatement_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
-		}
+    @Nested
+    @DisplayName("If-Statement-Tests")
+    class IfStatementTests {
+        @Test
+        void testHasBelowNoIfStatement_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
+        }
 
-		@Test
-		void testHasBelowNoIfStatement_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
-		}
-	}
+        @Test
+        void testHasBelowNoIfStatement_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.IFSTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("If-Expression-Tests")
-	class IfExpressionTests {
-		@Test
-		void testHasBelowNoIfExpression_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-					.hasNo(ConditionalType.CONDITIONALEXPR);
-		}
+    @Nested
+    @DisplayName("If-Expression-Tests")
+    class IfExpressionTests {
+        @Test
+        void testHasBelowNoIfExpression_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+                    .hasNo(ConditionalType.CONDITIONALEXPR);
+        }
 
-		@Test
-		void testHasBelowNoIfExpression_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-					.hasNo(ConditionalType.CONDITIONALEXPR);
-		}
-	}
+        @Test
+        void testHasBelowNoIfExpression_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+                    .hasNo(ConditionalType.CONDITIONALEXPR);
+        }
+    }
 
-	@Nested
-	@DisplayName("Switch-Statement-Tests")
-	class SwitchStatementTests {
-		@Test
-		void testHasBelowNoSwitchStatement_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
-		}
+    @Nested
+    @DisplayName("Switch-Statement-Tests")
+    class SwitchStatementTests {
+        @Test
+        void testHasBelowNoSwitchStatement_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
+        }
 
-		@Test
-		void testHasBelowNoSwitchStatement_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
-		}
-	}
+        @Test
+        void testHasBelowNoSwitchStatement_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHSTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("Switch-Expression-Tests")
-	class SwitchExpressionTests {
-		@Test
-		void testHasBelowNoSwitchExpression_Success() throws IOException {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
-		}
+    @Nested
+    @DisplayName("Switch-Expression-Tests")
+    class SwitchExpressionTests {
+        @Test
+        void testHasBelowNoSwitchExpression_Success() throws IOException {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
+        }
 
-		@Test
-		void testHasBelowNoSwitchExpression_Fail() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
-		}
-	}
+        @Test
+        void testHasBelowNoSwitchExpression_Fail() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.SWITCHEXPR);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-If-Tests")
-	class AnyIfTests {
-		@Test
-		void testHasBelowNoAnyIf_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
-		}
+    @Nested
+    @DisplayName("Any-If-Tests")
+    class AnyIfTests {
+        @Test
+        void testHasBelowNoAnyIf_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
+        }
 
-		@Test
-		void testHasBelowNoAnyIf_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyIf_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".conditionals.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_IF);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-Switch-Tests")
-	class AnySwitchTests {
-		@Test
-		void testHasBelowNoAnySwitch_Success() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
-		}
+    @Nested
+    @DisplayName("Any-Switch-Tests")
+    class AnySwitchTests {
+        @Test
+        void testHasBelowNoAnySwitch_Success() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
+        }
 
-		@Test
-		void testHasBelowNoAnySwitch_Fail() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
-		}
-	}
+        @Test
+        void testHasBelowNoAnySwitch_Fail() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY_SWITCH);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-Conditional-Tests")
-	class AnyConditionalTests {
-		@Test
-		void testHasBelowNoAnyConditional_Success() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
-		}
+    @Nested
+    @DisplayName("Any-Conditional-Tests")
+    class AnyConditionalTests {
+        @Test
+        void testHasBelowNoAnyConditional_Success() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "no")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
+        }
 
-		@Test
-		void testHasBelowNoAnyConditional_Fail() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyConditional_Fail() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("conditionals", "yes")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ConditionalType.ANY);
+        }
+    }
 
-	@Nested
-	@DisplayName("Class-Tests")
-	class ClassTests {
-		@Test
-		void testHasBelowNoClass_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
-		}
+    @Nested
+    @DisplayName("Class-Tests")
+    class ClassTests {
+        @Test
+        void testHasBelowNoClass_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
+        }
 
-		@Test
-		void testHasBelowNoClass_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
-		}
-	}
+        @Test
+        void testHasBelowNoClass_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".classes.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.CLASS);
+        }
+    }
 
-	@Nested
-	@DisplayName("Record-Tests")
-	class RecordTests {
-		@Test
-		void testHasBelowNoRecord_Success() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
-		}
+    @Nested
+    @DisplayName("Record-Tests")
+    class RecordTests {
+        @Test
+        void testHasBelowNoRecord_Success() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
+        }
 
-		@Test
-		void testHasBelowNoRecord_Fail() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
-		}
-	}
+        @Test
+        void testHasBelowNoRecord_Fail() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.RECORD);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-Class-Tests")
-	class AnyClassTests {
-		@Test
-		void testHasBelowNoAnyClass_Success() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
-		}
+    @Nested
+    @DisplayName("Any-Class-Tests")
+    class AnyClassTests {
+        @Test
+        void testHasBelowNoAnyClass_Success() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "no")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
+        }
 
-		@Test
-		void testHasBelowNoAnyClass_Fail() {
-			UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyClass_Fail() {
+            UnwantedNodesAssert.assertThatSourcesIn(UNSUPPORTED_LEVEL_BASE_PATH.resolve(Path.of("classes", "yes")))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ClassType.ANY);
+        }
+    }
 
-	@Nested
-	@DisplayName("Assert-Exception-Handling-Tests")
-	class AssertExceptionHandlingTests {
-		@Test
-		void testHasBelowNoAssertExceptionHandling_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
-		}
+    @Nested
+    @DisplayName("Assert-Exception-Handling-Tests")
+    class AssertExceptionHandlingTests {
+        @Test
+        void testHasBelowNoAssertExceptionHandling_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
+        }
 
-		@Test
-		void testHasBelowNoAssertExceptionHandling_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
-		}
-	}
+        @Test
+        void testHasBelowNoAssertExceptionHandling_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ASSERT);
+        }
+    }
 
-	@Nested
-	@DisplayName("Throw-Exception-Handling-Tests")
-	class ThrowExceptionHandlingTests {
-		@Test
-		void testHasBelowNoThrowExceptionHandling_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
-		}
+    @Nested
+    @DisplayName("Throw-Exception-Handling-Tests")
+    class ThrowExceptionHandlingTests {
+        @Test
+        void testHasBelowNoThrowExceptionHandling_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
+        }
 
-		@Test
-		void testHasBelowNoThrowExceptionHandling_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
-		}
-	}
+        @Test
+        void testHasBelowNoThrowExceptionHandling_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.THROW);
+        }
+    }
 
-	@Nested
-	@DisplayName("Catch-Exception-Handling-Tests")
-	class CatchExceptionHandlingTests {
-		@Test
-		void testHasBelowNoCatchExceptionHandling_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
-		}
+    @Nested
+    @DisplayName("Catch-Exception-Handling-Tests")
+    class CatchExceptionHandlingTests {
+        @Test
+        void testHasBelowNoCatchExceptionHandling_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
+        }
 
-		@Test
-		void testHasBelowNoCatchExceptionHandling_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
-		}
-	}
+        @Test
+        void testHasBelowNoCatchExceptionHandling_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.CATCH);
+        }
+    }
 
-	@Nested
-	@DisplayName("Any-Exception-Handling-Tests")
-	class AnyExceptionHandlingTests {
-		@Test
-		void testHasBelowNoAnyExceptionHandling_Success() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
-		}
+    @Nested
+    @DisplayName("Any-Exception-Handling-Tests")
+    class AnyExceptionHandlingTests {
+        @Test
+        void testHasBelowNoAnyExceptionHandling_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
+        }
 
-		@Test
-		void testHasBelowNoAnyExceptionHandling_Fail() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
-		}
-	}
+        @Test
+        void testHasBelowNoAnyExceptionHandling_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".exceptionHandlings.yes")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(ExceptionHandlingType.ANY);
+        }
+    }
 
-	@Nested
-	@DisplayName("PomXml-Tests")
-	class PomXmlTests {
-		@Test
-		void testPomXmlFileDoesExist() {
-			AresConfiguration.setBuildGradlePath(null);
-			AresConfiguration.setPomXmlPath("src/test/resources/de/tum/in/test/integration/testuser/pom.xml");
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
-		}
-	}
+    @Nested
+    @DisplayName("PomXml-Tests")
+    class PomXmlTests {
+        @Test
+        void testPomXmlFileDoesExist() {
+            AresConfiguration.setBuildGradlePath(null);
+            AresConfiguration.setPomXmlPath("src/test/resources/de/tum/in/test/integration/testuser/pom.xml");
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".loops.no")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.FORSTMT);
+        }
+    }
 
-	@Nested
-	@DisplayName("Error-Tests")
-	class ErrorTests {
+    @Nested
+    @DisplayName("Error-Tests")
+    class ErrorTests {
 
-		@Test
-		void testPathDoesNotExist() {
-			UnwantedNodesAssert.assertThatSourcesIn(Path.of("this", "path", "does", "not", "exist"))
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
+        @Test
+        void testPathDoesNotExist() {
+            UnwantedNodesAssert.assertThatSourcesIn(Path.of("this", "path", "does", "not", "exist"))
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testPathIsNull() {
-			UnwantedNodesAssert.assertThatSourcesIn(null).withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-					.hasNo(LoopType.ANY);
-		}
+        @Test
+        void testPathIsNull() {
+            UnwantedNodesAssert.assertThatSourcesIn(null).withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+                    .hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testPackageDoesNotExist() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage("this.package.name.does.not.exist")
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
+        @Test
+        void testPackageDoesNotExist() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage("this.package.name.does.not.exist")
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testPackageIsNull() {
-			UnwantedNodesAssert.assertThatProjectSources().withinPackage(null)
-					.withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
-		}
+        @Test
+        void testPackageIsNull() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(null)
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testBuildGradleFileDoesNotExist() {
-			AresConfiguration.setBuildGradlePath("does/not/exist/build.bradle");
-			UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-					.hasNo(LoopType.ANY);
-		}
+        @Test
+        void testBuildGradleFileDoesNotExist() {
+            AresConfiguration.setBuildGradlePath("does/not/exist/build.bradle");
+            UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+                    .hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testBuildGradleFileIsNull() {
-			AresConfiguration.setBuildGradlePath(null);
-			UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
-					.hasNo(LoopType.ANY);
-		}
+        @Test
+        void testBuildGradleFileIsNull() {
+            AresConfiguration.setBuildGradlePath(null);
+            UnwantedNodesAssert.assertThatProjectSources().withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
+                    .hasNo(LoopType.ANY);
+        }
 
-		@Test
-		void testLevelIsNull() {
-			UnwantedNodesAssert.assertThatProjectSources().hasNo(LoopType.ANY);
-		}
-	}
+        @Test
+        void testLevelIsNull() {
+            UnwantedNodesAssert.assertThatProjectSources().hasNo(LoopType.ANY);
+        }
+    }
+
+    @Nested
+    @DisplayName("Exclude-Main-Tests")
+    class ExcludeErrorTests {
+        @Test
+        void testHasBelowNoLoopsOutsideMainMethod_Success() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.no")
+                    .excludeMainMethod()
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
+
+        @Test
+        void testHasBelowNoLoopsOutsideMainMethod_Fail() {
+            UnwantedNodesAssert.assertThatProjectSources().withinPackage(BASE_PACKAGE + ".excludeMain.yes")
+                    .excludeMainMethod()
+                    .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17).hasNo(LoopType.ANY);
+        }
+    }
 }

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/astTestFiles/excludeMain/no/ClassWithNoLoopsOutsideMainMethod.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/astTestFiles/excludeMain/no/ClassWithNoLoopsOutsideMainMethod.java
@@ -1,0 +1,57 @@
+package de.tum.in.test.integration.testuser.subject.structural.astTestFiles.excludeMain.no;
+
+public class ClassWithNoLoopsOutsideMainMethod {
+
+	public void ifStatement() {
+		int x = 3;
+		if (x == 1) {
+			System.out.println("Hello");
+		} else if (x == 0) {
+			System.out.println("World");
+		} else {
+			System.out.println("!");
+		}
+	}
+
+	public void ifExpression() {
+		int x = 3;
+		System.out.println(x == 1 ? "Hello" : (x == 0 ? "World" : "!"));
+	}
+
+	public void switchStatement() {
+		String output;
+		switch (3) {
+		case 1:
+			output = "Hello";
+			break;
+		case 0:
+			output = "World";
+			break;
+		default:
+			output = "!";
+			break;
+		}
+		System.out.println(output);
+	}
+
+	public void assertStatement() {
+		assert 3 == 0;
+	}
+
+	public void throwStatement() throws Exception {
+		throw new Exception("This is a checked exception.");
+	}
+
+	public void catchStatement() {
+		try {
+			throwStatement();
+		} catch (Exception e) {
+		}
+	}
+
+	public static void main(String[] args) {
+		for (int i = 0; i < args.length; i++) {
+			int x = i;
+		}
+	}
+}

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/astTestFiles/excludeMain/yes/ClassWithLoopOutsideMainMethod.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/astTestFiles/excludeMain/yes/ClassWithLoopOutsideMainMethod.java
@@ -1,0 +1,18 @@
+package de.tum.in.test.integration.testuser.subject.structural.astTestFiles.excludeMain.yes;
+
+public class ClassWithLoopOutsideMainMethod {
+
+	public void forLoop() {
+		for (int i = 0; i < 3; i++) {
+			System.out.println("Hello World");
+		}
+	}
+
+	public static void main(String[] args) {
+		if (args.length > 0) {
+			System.out.println("Hello World");
+		}
+	}
+
+
+}

--- a/src/test/java/de/tum/in/test/integration/testuser/subject/structural/astTestFiles/excludeMain/yes/ClassWithLoopOutsideMainMethod.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/subject/structural/astTestFiles/excludeMain/yes/ClassWithLoopOutsideMainMethod.java
@@ -13,6 +13,4 @@ public class ClassWithLoopOutsideMainMethod {
 			System.out.println("Hello World");
 		}
 	}
-
-
 }


### PR DESCRIPTION
Improved the current AST functionality to allow instructors to exclude the Main method from AST checks.

- Added a method, `excludeMain()`, to avoid AST checking of the Main method, as it is removed from the AST.