### PR TITLE
`Development`: Add annotation to disable thread group check

### DIFF
--- a/src/main/java/de/tum/in/test/api/DisableThreadGroupCheck.java
+++ b/src/main/java/de/tum/in/test/api/DisableThreadGroupCheck.java
@@ -1,0 +1,26 @@
+package de.tum.in.test.api;
+
+import org.apiguardian.api.API;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Disables the Thread Group Check.
+ *
+ * @author Benjamin Schmitz
+ * @since 1.14.0
+ * @version 1.0.0
+ */
+@API(status = API.Status.EXPERIMENTAL)
+@Inherited
+@Documented
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD, ANNOTATION_TYPE })
+public @interface DisableThreadGroupCheck {
+}

--- a/src/main/java/de/tum/in/test/api/internal/ConfigurationUtils.java
+++ b/src/main/java/de/tum/in/test/api/internal/ConfigurationUtils.java
@@ -111,7 +111,7 @@ public final class ConfigurationUtils {
 				.orElse(TrustScope.MINIMAL);
 	}
 
-	public static Boolean isThreadGroupCheckDisabled(TestContext context) {
+	public static boolean isThreadGroupCheckDisabled(TestContext context) {
 		return TestContextUtils.findAnnotationIn(context, DisableThreadGroupCheck.class).isPresent();
 	}
 }

--- a/src/main/java/de/tum/in/test/api/internal/ConfigurationUtils.java
+++ b/src/main/java/de/tum/in/test/api/internal/ConfigurationUtils.java
@@ -33,6 +33,7 @@ public final class ConfigurationUtils {
 		config.withPackageWhitelist(generatePackageWhiteList(context));
 		config.withTrustedPackages(getTrustedPackages(context));
 		config.withThreadTrustScope(getThreadTrustScope(context));
+		config.withIsThreadGroupCheckDisabled(isThreadGroupCheckDisabled(context));
 		configureAllowLocalPort(config, context);
 		return config.build();
 	}
@@ -108,5 +109,9 @@ public final class ConfigurationUtils {
 	private static TrustScope getThreadTrustScope(TestContext context) {
 		return TestContextUtils.findAnnotationIn(context, TrustedThreads.class).map(TrustedThreads::value)
 				.orElse(TrustScope.MINIMAL);
+	}
+
+	public static Boolean isThreadGroupCheckDisabled(TestContext context) {
+		return TestContextUtils.findAnnotationIn(context, DisableThreadGroupCheck.class).isPresent();
 	}
 }

--- a/src/main/java/de/tum/in/test/api/security/AresSecurityConfiguration.java
+++ b/src/main/java/de/tum/in/test/api/security/AresSecurityConfiguration.java
@@ -26,12 +26,14 @@ public final class AresSecurityConfiguration {
 	private final Set<PackageRule> whitelistedPackages;
 	private final Set<PackageRule> trustedPackages;
 	private final TrustScope threadTrustScope;
+	private final boolean isThreadGroupCheckDisabled;
 
 	AresSecurityConfiguration(Optional<Class<?>> testClass, Optional<Method> testMethod, Path executionPath, // NOSONAR
 			Collection<String> whitelistedClassNames, Optional<Collection<PathRule>> whitelistedPaths,
 			Collection<PathRule> blacklistedPaths, Set<Integer> allowedLocalPorts, OptionalInt allowLocalPortsAbove,
 			Set<Integer> excludedLocalPorts, OptionalInt allowedThreadCount, Set<PackageRule> blacklistedPackages,
-			Set<PackageRule> whitelistedPackages, Set<PackageRule> trustedPackages, TrustScope threadTrustScope) {
+			Set<PackageRule> whitelistedPackages, Set<PackageRule> trustedPackages, TrustScope threadTrustScope,
+			boolean isThreadGroupCheckDisabled) {
 		this.testClass = Objects.requireNonNull(testClass);
 		this.testMethod = Objects.requireNonNull(testMethod);
 		this.executionPath = executionPath.toAbsolutePath();
@@ -46,6 +48,7 @@ public final class AresSecurityConfiguration {
 		this.whitelistedPackages = Set.copyOf(whitelistedPackages);
 		this.trustedPackages = Set.copyOf(trustedPackages);
 		this.threadTrustScope = threadTrustScope;
+		this.isThreadGroupCheckDisabled = isThreadGroupCheckDisabled;
 	}
 
 	public Optional<Class<?>> testClass() {
@@ -104,6 +107,10 @@ public final class AresSecurityConfiguration {
 		return threadTrustScope;
 	}
 
+	public boolean isThreadGroupCheckDisabled() {
+		return isThreadGroupCheckDisabled;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
@@ -122,13 +129,15 @@ public final class AresSecurityConfiguration {
 				&& Objects.equals(blacklistedPaths, other.blacklistedPaths)
 				&& Objects.equals(blacklistedPackages, other.blacklistedPackages)
 				&& Objects.equals(whitelistedPackages, other.whitelistedPackages)
-				&& Objects.equals(threadTrustScope, other.threadTrustScope);
+				&& Objects.equals(threadTrustScope, other.threadTrustScope)
+				&& Objects.equals(isThreadGroupCheckDisabled, other.isThreadGroupCheckDisabled);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(executionPath, testClass, testMethod, whitelistedClassNames, allowedThreadCount,
-				whitelistedPaths, blacklistedPaths, blacklistedPackages, whitelistedPackages, threadTrustScope);
+				whitelistedPaths, blacklistedPaths, blacklistedPackages, whitelistedPackages, threadTrustScope,
+				isThreadGroupCheckDisabled);
 	}
 
 	@Override
@@ -136,10 +145,11 @@ public final class AresSecurityConfiguration {
 		return String.format("AresSecurityConfiguration [whitelistedClassNames=%s, executionPath=%s," //$NON-NLS-1$
 				+ " testClass=%s, testMethod=%s, whitelistedPaths=%s, blacklistedPaths=%s, allowedLocalPorts=%s," //$NON-NLS-1$
 				+ " allowLocalPortsAbove=%s, excludedLocalPorts=%s, allowedThreadCount=%s," //$NON-NLS-1$
-				+ " blacklistedPackages=%s, whitelistedPackages=%s, trustedPackages=%s, threadTrustScope=%s]", //$NON-NLS-1$
+				+ " blacklistedPackages=%s, whitelistedPackages=%s, trustedPackages=%s, threadTrustScope=%s," //$NON-NLS-1$
+				+ " isThreadGroupCheckDisabled=%b]", //$NON-NLS-1$
 				whitelistedClassNames, executionPath, testClass, testMethod, whitelistedPaths, blacklistedPaths,
 				allowedLocalPorts, allowLocalPortsAbove, excludedLocalPorts, allowedThreadCount, blacklistedPackages,
-				whitelistedPackages, trustedPackages, threadTrustScope);
+				whitelistedPackages, trustedPackages, threadTrustScope, isThreadGroupCheckDisabled);
 	}
 
 	public String shortDesc() {

--- a/src/main/java/de/tum/in/test/api/security/AresSecurityConfigurationBuilder.java
+++ b/src/main/java/de/tum/in/test/api/security/AresSecurityConfigurationBuilder.java
@@ -60,6 +60,7 @@ public final class AresSecurityConfigurationBuilder {
 	private OptionalInt allowedThreadCount;
 	private Set<PackageRule> trustedPackages;
 	private TrustScope threadTrustScope;
+	private boolean isThreadGroupCheckDisabled;
 
 	private AresSecurityConfigurationBuilder() {
 		testClass = Optional.empty();
@@ -74,6 +75,7 @@ public final class AresSecurityConfigurationBuilder {
 		allowedThreadCount = OptionalInt.empty();
 		trustedPackages = Set.of();
 		threadTrustScope = TrustScope.MINIMAL;
+		isThreadGroupCheckDisabled = false;
 	}
 
 	public AresSecurityConfigurationBuilder withPath(Path executionPath) {
@@ -142,12 +144,17 @@ public final class AresSecurityConfigurationBuilder {
 		return this;
 	}
 
+	public AresSecurityConfigurationBuilder withIsThreadGroupCheckDisabled(boolean isThreadGroupCheckDisabled) {
+		this.isThreadGroupCheckDisabled = isThreadGroupCheckDisabled;
+		return this;
+	}
+
 	public AresSecurityConfiguration build() {
 		validate();
 		return new AresSecurityConfiguration(testClass, testMethod, executionPath, whitelistedClassNames,
 				Optional.ofNullable(whitelistedPaths), blacklistedPaths, allowedLocalPorts, allowLocalPortsAbove,
 				excludedLocalPorts, allowedThreadCount, blacklistedPackages, whitelistedPackages, trustedPackages,
-				threadTrustScope);
+				threadTrustScope, isThreadGroupCheckDisabled);
 	}
 
 	private void validate() {

--- a/src/main/java/de/tum/in/test/api/security/ArtemisSecurityManager.java
+++ b/src/main/java/de/tum/in/test/api/security/ArtemisSecurityManager.java
@@ -592,6 +592,11 @@ public final class ArtemisSecurityManager extends SecurityManager {
 	 */
 	@SuppressWarnings("deprecation")
 	private Thread[] checkThreadGroup() {
+		if (configuration.isThreadGroupCheckDisabled()) {
+			LOG.debug("Thread group check is disabled"); //$NON-NLS-1$
+			return new Thread[0];
+		}
+
 		blockThreadCreation = true;
 		int originalCount = testThreadGroup.activeCount();
 		if (originalCount == 0)


### PR DESCRIPTION
### Problem
When testing JavaFX exercises with TestFX, the tests fail because TestFX spawns additional threads in the thread group. These threads are terminated during thread group validation, which disrupts the TestFX testing process.

### Solution
Introduce a new optional annotation, `@DisableThreadGroupCheck`, that disables the thread group check when applied. This prevents the termination of threads spawned by TestFX, allowing the testing process to complete without interruptions.

You might have a look at how this is used for testing JavaFX exercises: https://github.com/bensofficial/javafx-example