### PR TITLE
Remove junit4 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,6 @@
 			<version>${junit-jupiter-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>${junit-jupiter-version}</version>
-			<scope>provided</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest</artifactId>
 			<version>2.2</version>

--- a/src/main/java/de/tum/in/test/api/internal/sanitization/MultipleFailuresErrorSanitizer.java
+++ b/src/main/java/de/tum/in/test/api/internal/sanitization/MultipleFailuresErrorSanitizer.java
@@ -1,7 +1,6 @@
 package de.tum.in.test.api.internal.sanitization;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.assertj.core.error.AssertJMultipleFailuresError;
 import org.opentest4j.MultipleFailuresError;
@@ -22,8 +21,7 @@ enum MultipleFailuresErrorSanitizer implements SpecificThrowableSanitizer {
 		MultipleFailuresError mfe = (MultipleFailuresError) t;
 		ThrowableInfo info = ThrowableInfo.getEssentialInfosSafeFrom(mfe).sanitize();
 		// list is safe here because of defensive copying in MultipleFailuresError
-		List<Throwable> failures = mfe.getFailures().stream().map(ThrowableSanitizer::sanitize)
-				.collect(Collectors.toUnmodifiableList());
+		List<Throwable> failures = mfe.getFailures().stream().map(ThrowableSanitizer::sanitize).toList();
 		/*
 		 * Message already contains the failures and separating both is more difficult.
 		 * So we just pass the message constructed be the old object, as the new object

--- a/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableInfo.java
+++ b/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableInfo.java
@@ -187,9 +187,10 @@ public final class ThrowableInfo {
 	 * Custom reconstruction of {@link AssertJMultipleFailuresError#getMessage()}.
 	 * <p>
 	 * AssertJ's own getMessage() implementation introspects nested failures and can
-	 * trigger reflection, which breaks when using {@link de.tum.in.test.api.internal.BlacklistedInvoker}.
-	 * To avoid that, we extract the failures, their messages,
-	 * and the first user-relevant stack frame ourselves without reflections.
+	 * trigger reflection, which breaks when using
+	 * {@link de.tum.in.test.api.internal.BlacklistedInvoker}. To avoid that, we
+	 * extract the failures, their messages, and the first user-relevant stack frame
+	 * ourselves without reflections.
 	 */
 	private static String saveAssertJMultipleFailuresMessage(AssertJMultipleFailuresError e) {
 		return invoke(() -> {

--- a/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableSets.java
+++ b/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableSets.java
@@ -26,7 +26,6 @@ final class ThrowableSets {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ThrowableSets.class);
 
-	private static final String JUNIT4_CHECK_CLASS = "junit.framework.AssertionFailedError"; //$NON-NLS-1$
 	private static final String JUNIT5_CHECK_CLASS = "org.junit.platform.commons.JUnitException"; //$NON-NLS-1$
 	private static final String JQWIK_CHECK_CLASS = "net.jqwik.api.JqwikException"; //$NON-NLS-1$
 	private static final String ASSERTJ_CHECK_CLASS = "org.assertj.core.api.Assertions"; //$NON-NLS-1$
@@ -35,8 +34,6 @@ final class ThrowableSets {
 	static {
 		HashSet<Class<? extends Throwable>> safeTypesJoin = new HashSet<>(Java.SAFE_TYPES);
 		safeTypesJoin.addAll(Own.SAFE_TYPES);
-		if (classCanBeFound(JUNIT4_CHECK_CLASS))
-			safeTypesJoin.addAll(JUnit4.SAFE_TYPES);
 		if (classCanBeFound(JUNIT5_CHECK_CLASS))
 			safeTypesJoin.addAll(JUnit5.SAFE_TYPES);
 		if (classCanBeFound(JQWIK_CHECK_CLASS))
@@ -204,25 +201,6 @@ final class ThrowableSets {
 				java.util.prefs.InvalidPreferencesFormatException.class, java.util.regex.PatternSyntaxException.class,
 				java.util.zip.DataFormatException.class, java.util.zip.ZipError.class,
 				java.util.zip.ZipException.class);
-	}
-
-	static final class JUnit4 {
-
-		private JUnit4() {
-		}
-
-		static final Set<Class<? extends Throwable>> SAFE_TYPES = Set.of(junit.framework.AssertionFailedError.class,
-				junit.framework.ComparisonFailure.class, org.junit.ComparisonFailure.class, org.junit.Test.None.class,
-				org.junit.TestCouldNotBeSkippedException.class,
-				org.junit.experimental.max.CouldNotReadCoreException.class,
-				org.junit.experimental.theories.PotentialAssignment.CouldNotGenerateValueException.class,
-				org.junit.experimental.theories.internal.ParameterizedAssertionError.class,
-				org.junit.internal.ArrayComparisonFailure.class,
-				org.junit.runner.FilterFactory.FilterNotCreatedException.class,
-				org.junit.runner.manipulation.InvalidOrderingException.class,
-				org.junit.runner.manipulation.NoTestsRemainException.class,
-				org.junit.runner.notification.StoppedByUserException.class,
-				org.junit.runners.model.TestTimedOutException.class);
 	}
 
 	static final class JUnit5 {

--- a/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableUtils.java
+++ b/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableUtils.java
@@ -149,4 +149,11 @@ final class ThrowableUtils {
 			return null;
 		}).toArray();
 	}
+
+	static String formatStackTraceElement(StackTraceElement ste) {
+		String className = ste.getClassName();
+		String simpleName = className.substring(className.lastIndexOf('.') + 1);
+		return "at " + simpleName + "." + ste.getMethodName() +
+				"(" + ste.getFileName() + ":" + ste.getLineNumber() + ")";
+	}
 }

--- a/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableUtils.java
+++ b/src/main/java/de/tum/in/test/api/internal/sanitization/ThrowableUtils.java
@@ -153,7 +153,7 @@ final class ThrowableUtils {
 	static String formatStackTraceElement(StackTraceElement ste) {
 		String className = ste.getClassName();
 		String simpleName = className.substring(className.lastIndexOf('.') + 1);
-		return "at " + simpleName + "." + ste.getMethodName() +
-				"(" + ste.getFileName() + ":" + ste.getLineNumber() + ")";
+		return "at " + simpleName + "." + ste.getMethodName() + "(" + ste.getFileName() + ":" + ste.getLineNumber()
+				+ ")";
 	}
 }

--- a/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
+++ b/src/test/java/de/tum/in/test/api/util/ClassMemberAccessorTest.java
@@ -1,7 +1,7 @@
 package de.tum.in.test.api.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.*;
 

--- a/src/test/java/de/tum/in/test/integration/ExceptionFailureTest.java
+++ b/src/test/java/de/tum/in/test/integration/ExceptionFailureTest.java
@@ -18,19 +18,19 @@ class ExceptionFailureTest {
 	@UserTestResults
 	private static Events tests;
 
-	private final String assertJMultipleFailures = "assertJMultipleFailures";
-	private final String assertionFailOnly = "assertionFailOnly";
-	private final String assertionFailed = "assertionFailed";
-	private final String customException = "customException";
-	private final String exceptionInInitializer = "exceptionInInitializer";
-	private final String faultyGetCauseException = "faultyGetCauseException";
-	private final String faultyToStringException = "faultyToStringException";
-	private final String multipleAssertions = "multipleAssertions";
-	private final String multipleFailures = "multipleFailures";
-	private final String nullPointer = "nullPointer";
-	private final String softAssertion = "softAssertion";
-	private final String throwExceptionInInitializerError = "throwExceptionInInitializerError";
-	private final String throwNullPointerException = "throwNullPointerException";
+	private static final String assertJMultipleFailures = "assertJMultipleFailures";
+	private static final String assertionFailOnly = "assertionFailOnly";
+	private static final String assertionFailed = "assertionFailed";
+	private static final String customException = "customException";
+	private static final String exceptionInInitializer = "exceptionInInitializer";
+	private static final String faultyGetCauseException = "faultyGetCauseException";
+	private static final String faultyToStringException = "faultyToStringException";
+	private static final String multipleAssertions = "multipleAssertions";
+	private static final String multipleFailures = "multipleFailures";
+	private static final String nullPointer = "nullPointer";
+	private static final String softAssertion = "softAssertion";
+	private static final String throwExceptionInInitializerError = "throwExceptionInInitializerError";
+	private static final String throwNullPointerException = "throwNullPointerException";
 
 	@TestTest
 	void test_assertJMultipleFailures() {
@@ -120,8 +120,8 @@ class ExceptionFailureTest {
 	void test_multipleFailures() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(multipleFailures, MultipleFailuresError.class, //
 				"Multiple Failures (2 failures)\n" + //
-						"\tjava.lang.AssertionError: A\n" + //
-						"\tjava.lang.AssertionError: B", //
+						"\torg.opentest4j.AssertionFailedError: A\n" + //
+						"\torg.opentest4j.AssertionFailedError: B", //
 				new Condition<>(t -> t.getSuppressed().length == 2, "two suppressed exceptions"),
 				Option.MESSAGE_NORMALIZE_NEWLINE));
 	}

--- a/src/test/java/de/tum/in/test/integration/InputOutputTest.java
+++ b/src/test/java/de/tum/in/test/integration/InputOutputTest.java
@@ -4,12 +4,12 @@ import static de.tum.in.test.testutilities.CustomConditions.*;
 
 import java.lang.annotation.AnnotationFormatError;
 
-import org.junit.ComparisonFailure;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.platform.testkit.engine.Events;
 
 import de.tum.in.test.integration.testuser.InputOutputUser;
 import de.tum.in.test.testutilities.*;
+import org.opentest4j.AssertionFailedError;
 
 @UserBased(InputOutputUser.class)
 class InputOutputTest {
@@ -58,7 +58,7 @@ class InputOutputTest {
 
 	@TestTest
 	void test_testPenguin2() {
-		tests.assertThatEvents().haveExactly(1, testFailedWith(testPenguin2, ComparisonFailure.class));
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testPenguin2, AssertionFailedError.class));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/in/test/integration/InputOutputTest.java
+++ b/src/test/java/de/tum/in/test/integration/InputOutputTest.java
@@ -6,10 +6,10 @@ import java.lang.annotation.AnnotationFormatError;
 
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.platform.testkit.engine.Events;
+import org.opentest4j.AssertionFailedError;
 
 import de.tum.in.test.integration.testuser.InputOutputUser;
 import de.tum.in.test.testutilities.*;
-import org.opentest4j.AssertionFailedError;
 
 @UserBased(InputOutputUser.class)
 class InputOutputTest {

--- a/src/test/java/de/tum/in/test/integration/SecurityTest.java
+++ b/src/test/java/de/tum/in/test/integration/SecurityTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 
-import org.junit.ComparisonFailure;
 import org.junit.platform.testkit.engine.Events;
 import org.opentest4j.AssertionFailedError;
 
@@ -53,7 +52,7 @@ class SecurityTest {
 
 	@TestTest
 	void test_longOutputJUnit4() {
-		tests.assertThatEvents().haveExactly(1, testFailedWith(longOutputJUnit4, ComparisonFailure.class));
+		tests.assertThatEvents().haveExactly(1, testFailedWith(longOutputJUnit4, AssertionFailedError.class));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/in/test/integration/testuser/ExceptionFailureUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ExceptionFailureUser.java
@@ -1,9 +1,9 @@
 package de.tum.in.test.integration.testuser;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.Serial;
 import java.util.*;
 
 import org.assertj.core.api.SoftAssertionError;
@@ -27,6 +27,7 @@ public class ExceptionFailureUser {
 
 	static class FaultyGetCauseException extends RuntimeException {
 
+		@Serial
 		private static final long serialVersionUID = 487618816288959774L;
 
 		public FaultyGetCauseException() {
@@ -41,6 +42,7 @@ public class ExceptionFailureUser {
 
 	static class FaultyToStringException extends RuntimeException {
 
+		@Serial
 		private static final long serialVersionUID = -3215361616244777479L;
 
 		public FaultyToStringException() {
@@ -62,20 +64,16 @@ public class ExceptionFailureUser {
 
 	@PublicTest
 	void assertJMultipleFailures() {
-		assertThat("ABC").satisfiesAnyOf(s -> {
-			fail("A");
-		}, s -> {
-			fail("B");
-		});
+		assertThat("ABC").satisfiesAnyOf(s -> fail("A"), s -> fail("B"));
 	}
 
 	@PublicTest
-	void assertionFailOnly() throws Exception {
+	void assertionFailOnly() {
 		org.junit.jupiter.api.Assertions.fail("This test failed. Penguin.");
 	}
 
 	@PublicTest
-	void assertionFailed() throws Exception {
+	void assertionFailed() {
 		assertEquals(1, 2);
 	}
 
@@ -107,11 +105,7 @@ public class ExceptionFailureUser {
 
 	@PublicTest
 	void multipleFailures() {
-		assertAll(() -> {
-			fail("A");
-		}, () -> {
-			fail("B");
-		});
+		assertAll(() -> fail("A"), () -> fail("B"));
 	}
 
 	@PublicTest

--- a/src/test/java/de/tum/in/test/integration/testuser/InputOutputUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/InputOutputUser.java
@@ -2,8 +2,8 @@ package de.tum.in.test.integration.testuser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -231,7 +231,7 @@ public class InputOutputUser {
 
 		var out = tester.out().getLines();
 
-		assertEquals("Keine Fehlerausgabe erwartet", 3, out.size());
+		assertEquals(3, out.size(), "Keine Fehlerausgabe erwartet");
 		assertEquals("Zahl eingeben:", out.get(0).text());
 		assertEquals("Ausgabe:", out.get(1).text());
 		assertEquals("25", out.get(2).text());
@@ -241,7 +241,7 @@ public class InputOutputUser {
 	void testSquareWrong(IOTester tester) {
 		InputOutputPenguin.calculateSquare();
 
-		assertEquals("Keine Fehlerausgabe erwartet", 0, tester.err().getLines().size());
+		assertEquals(0, tester.err().getLines().size(), "Keine Fehlerausgabe erwartet");
 	}
 
 	@Test

--- a/src/test/java/de/tum/in/test/integration/testuser/PathAccessUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/PathAccessUser.java
@@ -1,7 +1,5 @@
 package de.tum.in.test.integration.testuser;
 
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.concurrent.TimeUnit;
@@ -14,6 +12,8 @@ import de.tum.in.test.api.MirrorOutput.MirrorOutputPolicy;
 import de.tum.in.test.api.jupiter.PublicTest;
 import de.tum.in.test.api.localization.UseLocale;
 import de.tum.in.test.integration.testuser.subject.PathAccessPenguin;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 @UseLocale("en")
 @MirrorOutput(MirrorOutputPolicy.DISABLED)

--- a/src/test/java/de/tum/in/test/integration/testuser/PathAccessUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/PathAccessUser.java
@@ -1,5 +1,7 @@
 package de.tum.in.test.integration.testuser;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.concurrent.TimeUnit;
@@ -12,8 +14,6 @@ import de.tum.in.test.api.MirrorOutput.MirrorOutputPolicy;
 import de.tum.in.test.api.jupiter.PublicTest;
 import de.tum.in.test.api.localization.UseLocale;
 import de.tum.in.test.integration.testuser.subject.PathAccessPenguin;
-
-import static org.junit.jupiter.api.Assertions.fail;
 
 @UseLocale("en")
 @MirrorOutput(MirrorOutputPolicy.DISABLED)

--- a/src/test/java/de/tum/in/test/integration/testuser/PrivilegedExceptionUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/PrivilegedExceptionUser.java
@@ -1,6 +1,6 @@
 package de.tum.in.test.integration.testuser;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/de/tum/in/test/integration/testuser/SecurityUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/SecurityUser.java
@@ -1,6 +1,6 @@
 package de.tum.in.test.integration.testuser;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/de/tum/in/test/integration/testuser/ThreadUser.java
+++ b/src/test/java/de/tum/in/test/integration/testuser/ThreadUser.java
@@ -1,6 +1,5 @@
 package de.tum.in.test.integration.testuser;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Path;

--- a/src/test/java/de/tum/in/test/testutilities/CustomConditions.java
+++ b/src/test/java/de/tum/in/test/testutilities/CustomConditions.java
@@ -59,7 +59,7 @@ public final class CustomConditions {
 
 		conditions.add(instanceOf(errorType));
 		conditions.add(messageLocalized());
-		if (message != NO_MSG) {
+		if (!Objects.equals(message, NO_MSG)) {
 			conditions.add(createMessageCondition(message, optionSet));
 		}
 		if (customCondition != null) {


### PR DESCRIPTION
Junit4 is not used any more, as Junit5 has become mature and the default standard. We want to simplify maintenance and reduce code complexity